### PR TITLE
Refactor date picker and add custom date-fns locales

### DIFF
--- a/eform-client/e2e/Helpers/helper-functions.ts
+++ b/eform-client/e2e/Helpers/helper-functions.ts
@@ -2,7 +2,7 @@ import { Guid } from 'guid-typescript';
 
 const expect = require('chai').expect;
 
-export function generateRandmString(length: number = 36) {
+export function generateRandmString(length: number = 36): string {
   return Guid.raw().toString().slice(0, length);
 }
 
@@ -41,7 +41,7 @@ export async function testSorting(
   }
 }
 
-export function getRandomInt(min, max) {
+export function getRandomInt(min: number, max: number): number {
   min = Math.ceil(min);
   max = Math.floor(max);
   return Math.floor(Math.random() * (max - min)) + min;
@@ -52,21 +52,22 @@ export async function selectDateOnDatePicker(
   month: number,
   day: number
 ) {
-  await browser.pause(1000);
-  await (await $(`.owl-dt-calendar-control-content span`)).click();
-  await browser.pause(1000);
-  await (
-    await $$(`tbody span.owl-dt-calendar-cell-content`)[year - 2016]
-  ).click();
-  await browser.pause(1000);
-  await (await $$(`span.owl-dt-calendar-cell-content`)[month - 1]).click();
-  await browser.pause(1000);
-  await (
-    await $$(
-      `span.owl-dt-calendar-cell-content:not(.owl-dt-calendar-cell-out)`
-    )[day - 1]
-  ).click();
-  await browser.pause(1000);
+  // need open selector years (selected year can be not needed year)
+  const selectYearAndMonthButton = await $(`.mat-calendar-period-button`);
+  await selectYearAndMonthButton.waitForClickable({timeout: 20000});
+  await selectYearAndMonthButton.click();
+  // select year. after select year we can select month
+  const yearForSelect = await $$(`mat-multi-year-view .mat-calendar-body-cell`)[year - 2016];
+  await yearForSelect.waitForClickable({timeout: 20000});
+  await yearForSelect.click();
+  // select month. after select month we can select day
+  const monthForSelect = await $$(`mat-year-view .mat-calendar-body-cell`)[month - 1];
+  await monthForSelect.waitForClickable({timeout: 20000});
+  await monthForSelect.click();
+  // select day
+  const dayForSelect = await $$(`mat-month-view .mat-calendar-body-cell`)[day - 1];
+  await dayForSelect.waitForClickable({timeout: 20000});
+  await dayForSelect.click();
 }
 
 export async function selectDateRangeOnDatePicker(
@@ -77,6 +78,7 @@ export async function selectDateRangeOnDatePicker(
   monthTo: number,
   dayTo: number,
 ) {
+  await (await $('.mat-datepicker-popup')).waitForDisplayed({timeout: 20000})
   await selectDateOnDatePicker(yearFrom, monthFrom, dayFrom);
   await selectDateOnDatePicker(yearTo, monthTo, dayTo);
 }

--- a/eform-client/src/app/app.declarations.ts
+++ b/eform-client/src/app/app.declarations.ts
@@ -58,6 +58,10 @@ import {AppMenuStateService, AuthStateService} from 'src/app/common/store';
 import {persistProviders} from 'src/app/common/store/persist.config';
 import {BaseService} from 'src/app/common/services/base.service';
 import {DateInterceptor} from 'src/app/common/interceptors/date.interceptor';
+import {MAT_DATE_FNS_FORMATS, DateFnsAdapter} from '@angular/material-date-fns-adapter';
+import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
+import {EformDateFnsDateAdapter} from 'src/app/common/modules/eform-date-adapter/eform-mat-datefns-date-adapter';
+import {BehaviorSubject} from 'rxjs';
 // Guards
 
 export let providers = [
@@ -101,6 +105,7 @@ export let providers = [
   NavigationMenuService,
   LoaderService,
   TitleService,
+  EformDateFnsDateAdapter,
   {provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true},
   {provide: HTTP_INTERCEPTORS, useClass: HttpErrorInterceptor, multi: true},
   {provide: HTTP_INTERCEPTORS, useClass: DateInterceptor, multi: true},
@@ -112,6 +117,9 @@ export let providers = [
       counterPosition: 'bottom',
     },
   },
+  // {provide: DateAdapter<any>, useClass: EformDateFnsDateAdapter, deps: [MAT_DATE_LOCALE],},
+  {provide: MAT_DATE_FORMATS, useValue: MAT_DATE_FNS_FORMATS},
+  {provide: MAT_DATE_LOCALE, useValue: new BehaviorSubject(null)},
   AuthStateService,
   AppMenuStateService,
   // Helpers

--- a/eform-client/src/app/app.module.ts
+++ b/eform-client/src/app/app.module.ts
@@ -47,6 +47,10 @@ import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatCardModule} from '@angular/material/card';
 import {MatInputModule} from '@angular/material/input';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {
+  EformDateFnsDateModule,
+  EformMatDateFnsDateModule
+} from 'src/app/common/modules/eform-date-adapter/eform-mat-datefns-date-adapter.module';
 
 @NgModule({
   declarations: [
@@ -97,6 +101,8 @@ import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
     OwlNativeDateTimeModule,
     EformSharedModule,
     MatProgressSpinnerModule,
+    // EformDateFnsDateModule,
+    EformMatDateFnsDateModule
   ],
   schemas: [NO_ERRORS_SCHEMA],
   providers: [providers],

--- a/eform-client/src/app/common/const/custom-date-fns-locales.ts
+++ b/eform-client/src/app/common/const/custom-date-fns-locales.ts
@@ -1,0 +1,99 @@
+import {Locale} from 'date-fns';
+import {da} from 'date-fns/locale';
+
+export const customDaLocale: Locale = {
+  ...da,
+  formatLong: {
+    ...da.formatLong,
+    date: buildFormatLongFn({
+      formats: {
+        full: 'EEEE, d MMMM y',
+        long: 'd MMMM y',
+        medium: 'd MMM y',
+        short: 'dd.MM.y',
+      },
+      defaultWidth: 'full',
+    }),
+  },
+  localize: {
+    ...da.localize,
+    ordinalNumber: (
+      dirtyNumber,
+      _options
+    ) => Number(dirtyNumber).toString(),
+    month: buildLocalizeFn({
+      values: {
+        narrow: ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'] as const,
+        abbreviated: [
+          'jan',
+          'feb',
+          'mar',
+          'apr',
+          'maj',
+          'jun',
+          'jul',
+          'aug',
+          'sep',
+          'okt',
+          'nov',
+          'dec',
+        ] as const,
+        wide: [
+          'januar',
+          'februar',
+          'marts',
+          'april',
+          'maj',
+          'juni',
+          'juli',
+          'august',
+          'september',
+          'oktober',
+          'november',
+          'december',
+        ] as const,
+      },
+      defaultWidth: 'wide',
+    }),
+  }
+};
+
+/// https://github.com/date-fns/date-fns/blob/main/src/locale/_lib/buildLocalizeFn/index.ts
+function buildLocalizeFn(args) {
+  return (dirtyIndex, options) => {
+    const context = options?.context ? String(options.context) : 'standalone'
+
+    let valuesArray
+    if (context === 'formatting' && args.formattingValues) {
+      const defaultWidth = args.defaultFormattingWidth || args.defaultWidth
+      const width = (options?.width
+        ? String(options.width)
+        : defaultWidth)
+      valuesArray = (args.formattingValues[width] ||
+        args.formattingValues[defaultWidth])
+    } else {
+      const defaultWidth = args.defaultWidth
+      const width = (options?.width
+        ? String(options.width)
+        : args.defaultWidth)
+      valuesArray = (args.values[width] ||
+        args.values[defaultWidth])
+    }
+    const index = (args.argumentCallback
+      ? args.argumentCallback(dirtyIndex)
+      : ((dirtyIndex) as unknown))
+    return valuesArray[index]
+  }
+}
+
+function buildFormatLongFn(args) {
+  return (options = {}) => {
+    // @ts-ignore
+    const width = options.width
+      // @ts-ignore
+      ? (String(options.width) as FormatLongWidth)
+      : args.defaultWidth
+    const format = args.formats[width] || args.formats[args.defaultWidth]
+    return format
+  }
+}

--- a/eform-client/src/app/common/const/index.ts
+++ b/eform-client/src/app/common/const/index.ts
@@ -6,3 +6,4 @@ export * from './eforms-permissions.const';
 export * from './date-formats';
 export * from './hours-picker-array.const';
 export * from './icons.const';
+export * from './custom-date-fns-locales';

--- a/eform-client/src/app/common/modules/eform-cases/components/case-edit/case-elements/element-date/element-date.component.html
+++ b/eform-client/src/app/common/modules/eform-cases/components/case-edit/case-elements/element-date/element-date.component.html
@@ -1,19 +1,17 @@
-<mat-form-field [owlDateTimeTrigger]="dt1">
-  <mat-label>{{ 'Start date' | translate }}</mat-label>
-  <mat-icon matPrefix>calendar_today</mat-icon>
+<mat-form-field>
+  <mat-label>{{ 'Select date' | translate }}</mat-label>
+  <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
   <input
+    [required]="fieldValueObj.mandatory"
     matInput
-    [ngModel]="fieldValueObj.value"
-    required
-    type="text"
-    [owlDateTime]="dt1"
-    id="startDate"
-    name="startDate"
-    (dateTimeChange)="onDateSelected($event)"
+    [matDatepicker]="picker"
+    [value]="fieldValueObj.value"
+    (dateChange)="onDateSelected($event)"
+    (dateInput)="onDateSelected($event)"
+    (click)="picker.open()"
   >
+  <mat-datepicker #picker></mat-datepicker>
+  <mat-error class="text-warn" *ngIf="!fieldValueObj.value && fieldValueObj.mandatory">
+    {{'Date is required'| translate}}*
+  </mat-error>
 </mat-form-field>
-<owl-date-time
-  [pickerType]="'calendar'" #dt1
-  [firstDayOfWeek]="1">
-</owl-date-time>
-

--- a/eform-client/src/app/common/modules/eform-cases/eform-cases.module.ts
+++ b/eform-client/src/app/common/modules/eform-cases/eform-cases.module.ts
@@ -56,7 +56,7 @@ import {MatTooltipModule} from '@angular/material/tooltip';
 import {MatDialogModule} from '@angular/material/dialog';
 import {MatInputModule} from '@angular/material/input';
 import {MtxSelectModule} from '@ng-matero/extensions/select';
-import {NgSelectModule} from '@ng-select/ng-select';
+import {MatDatepickerModule} from '@angular/material/datepicker';
 
 @NgModule({
     imports: [
@@ -81,7 +81,7 @@ import {NgSelectModule} from '@ng-select/ng-select';
         MatDialogModule,
         MatInputModule,
         MtxSelectModule,
-        NgSelectModule,
+        MatDatepickerModule,
     ],
   declarations: [
     CaseEditNavComponent,

--- a/eform-client/src/app/modules/cases/cases.module.ts
+++ b/eform-client/src/app/modules/cases/cases.module.ts
@@ -1,17 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import {
-  OWL_DATE_TIME_FORMATS,
-  OwlDateTimeModule,
-  // OwlMomentDateTimeModule,
-} from '@danielmoncada/angular-datetime-picker';
-import { NgSelectModule } from '@ng-select/ng-select';
 import { GalleryModule } from '@ngx-gallery/core';
 import { GallerizeModule } from '@ngx-gallery/gallerize';
 import { LightboxModule } from '@ngx-gallery/lightbox';
 import { TranslateModule } from '@ngx-translate/core';
-import { MY_MOMENT_FORMATS } from 'src/app/common/helpers';
 import { EformCasesModule } from 'src/app/common/modules/eform-cases/eform-cases.module';
 import { EformImportedModule } from 'src/app/common/modules/eform-imported/eform-imported.module';
 import { EformSharedModule } from 'src/app/common/modules/eform-shared/eform-shared.module';
@@ -25,6 +18,7 @@ import {MatTooltipModule} from '@angular/material/tooltip';
 import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
 import {MatCardModule} from '@angular/material/card';
+import {MatDatepickerModule} from '@angular/material/datepicker';
 
 @NgModule({
   imports: [
@@ -32,13 +26,10 @@ import {MatCardModule} from '@angular/material/card';
     EformSharedModule,
     CasesRoutingModule,
     CommonModule,
-    NgSelectModule,
     EformImportedModule,
     GallerizeModule,
     LightboxModule,
     GalleryModule,
-    OwlDateTimeModule,
-    // OwlMomentDateTimeModule,
     FormsModule,
     EformCasesModule,
     MatSortModule,
@@ -48,10 +39,10 @@ import {MatCardModule} from '@angular/material/card';
     MatIconModule,
     MatButtonModule,
     MatCardModule,
+    MatDatepickerModule,
   ],
   declarations: [CasesTableComponent, CaseEditComponent],
   providers: [
-    { provide: OWL_DATE_TIME_FORMATS, useValue: MY_MOMENT_FORMATS },
     casesPersistProvider,
   ],
 })

--- a/eform-client/src/app/modules/cases/components/case-edit/case-edit.component.html
+++ b/eform-client/src/app/modules/cases/components/case-edit/case-edit.component.html
@@ -11,19 +11,18 @@
         {{ 'Done at' | translate }}
       </mat-card-title>
       <mat-card-content>
-        <mat-form-field [owlDateTimeTrigger]="dt1">
+        <mat-form-field>
           <mat-label>{{ 'Select date' | translate }}</mat-label>
-          <mat-icon matPrefix>calendar_today</mat-icon>
+          <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
           <input
-            matInput
-            id="doneAt"
-            name="doneAt"
-            [owlDateTime]="dt1"
-            [(ngModel)]="replyElement.doneAt"
             required
-            type="text"
+            matInput
+            [matDatepicker]="picker"
+            [value]="replyElement.doneAt"
+            (dateChange)="replyElement.doneAt = $event.value"
+            (click)="picker.open()"
           >
-          <owl-date-time [pickerType]="'calendar'" #dt1 [firstDayOfWeek]="1"></owl-date-time>
+          <mat-datepicker #picker></mat-datepicker>
           <mat-error class="text-warn" *ngIf="!replyElement.doneAt">
             {{'Date is required'| translate}}*
           </mat-error>
@@ -46,22 +45,22 @@
         {{ replyElement.label }}
       </mat-card-title>
       <mat-card-content style="max-height: 50vh; overflow: auto;">
-          <div
-            *ngFor="let element of replyElement.elementList"
-            style="cursor: pointer"
-            routerLinkActive="active"
+        <div
+          *ngFor="let element of replyElement.elementList"
+          style="cursor: pointer"
+          routerLinkActive="active"
+        >
+          <a
+            mat-button
+            (click)="goToSection('#section' + element.id)"
+            class="d-flex w-100"
           >
-            <a
-              mat-button
-              (click)="goToSection('#section' + element.id)"
-              class="d-flex w-100"
-            >
-              {{ element.label }}
-            </a>
-            <ng-container *ngIf="element.elementList">
-              <app-case-edit-nav [element]="element"></app-case-edit-nav>
-            </ng-container>
-          </div>
+            {{ element.label }}
+          </a>
+          <ng-container *ngIf="element.elementList">
+            <app-case-edit-nav [element]="element"></app-case-edit-nav>
+          </ng-container>
+        </div>
       </mat-card-content>
       <mat-card-footer
         *ngIf="checkEformPermissions(userClaimsEnum.caseUpdate)"

--- a/eform-client/src/app/modules/eforms/eform-xlsx-report/components/eform-xlsx-report-header/eform-xlsx-report-header.component.html
+++ b/eform-client/src/app/modules/eforms/eform-xlsx-report/components/eform-xlsx-report-header/eform-xlsx-report-header.component.html
@@ -1,19 +1,14 @@
 <form [formGroup]="generateForm" style="width: 20%">
-  <mat-form-field [owlDateTimeTrigger]="dateRangePicker">
+  <mat-form-field>
     <mat-label>{{ 'Select date range' | translate }}</mat-label>
-    <mat-icon matPrefix>calendar_today</mat-icon>
-    <input
-      matInput
-      formControlName="dateRange"
-      name="dateRange"
-      required
-      [(ngModel)]="range"
-      type="text"
-      [owlDateTime]="dateRangePicker"
-      [selectMode]="'range'"
-      id="dateFormInput"
-    >
+    <mat-datepicker-toggle matPrefix [for]="picker"></mat-datepicker-toggle>
+    <mat-date-range-input [rangePicker]="picker" (click)="picker.open()">
+      <input formControlName="startDate" matStartDate>
+      <input formControlName="endDate" matEndDate>
+    </mat-date-range-input>
+    <mat-date-range-picker #picker></mat-date-range-picker>
   </mat-form-field>
+
   <button
     mat-raised-button
     color="accent"
@@ -23,9 +18,3 @@
     {{ 'Download' | translate }}
   </button>
 </form>
-
-<owl-date-time
-  [pickerType]="'calendar'"
-  [firstDayOfWeek]="1"
-  #dateRangePicker
-></owl-date-time>

--- a/eform-client/src/app/modules/eforms/eform-xlsx-report/components/eform-xlsx-report-header/eform-xlsx-report-header.component.ts
+++ b/eform-client/src/app/modules/eforms/eform-xlsx-report/components/eform-xlsx-report-header/eform-xlsx-report-header.component.ts
@@ -1,10 +1,10 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { EformDocxReportGenerateModel } from 'src/app/common/models';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { DateTimeAdapter } from '@danielmoncada/angular-datetime-picker';
-import { LocaleService } from 'src/app/common/services';
-import { format } from 'date-fns';
-import { AuthStateService } from 'src/app/common/store';
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {EformDocxReportGenerateModel} from 'src/app/common/models';
+import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
+import {DateTimeAdapter} from '@danielmoncada/angular-datetime-picker';
+import {LocaleService} from 'src/app/common/services';
+import {format} from 'date-fns';
+import {AuthStateService} from 'src/app/common/store';
 
 @Component({
   selector: 'app-eform-xlsx-report-header',
@@ -21,15 +21,15 @@ export class EformXlsxReportHeaderComponent implements OnInit {
   constructor(
     dateTimeAdapter: DateTimeAdapter<any>,
     private localeService: LocaleService,
-    private formBuilder: FormBuilder,
     authStateService: AuthStateService
   ) {
     dateTimeAdapter.setLocale(authStateService.currentUserLocale);
   }
 
   ngOnInit() {
-    this.generateForm = this.formBuilder.group({
-      dateRange: ['', Validators.required],
+    this.generateForm = new FormGroup({
+      startDate: new FormControl<Date | null>(null, Validators.required),
+      endDate: new FormControl<Date | null>(null, Validators.required),
     });
   }
 
@@ -38,10 +38,10 @@ export class EformXlsxReportHeaderComponent implements OnInit {
     this.downloadReport.emit(model);
   }
 
-  private extractData(formValue: any): EformDocxReportGenerateModel {
+  private extractData(formValue: { startDate: Date, endDate: Date }): EformDocxReportGenerateModel {
     return new EformDocxReportGenerateModel({
-      dateFrom: format(formValue.dateRange[0], 'yyyy-MM-dd'),
-      dateTo: format(formValue.dateRange[1], 'yyyy-MM-dd'),
+      dateFrom: format(formValue.startDate, 'yyyy-MM-dd'),
+      dateTo: format(formValue.endDate, 'yyyy-MM-dd'),
       templateId: this.templateId,
     });
   }

--- a/eform-client/src/app/modules/eforms/eform-xlsx-report/eform-xlsx-report.module.ts
+++ b/eform-client/src/app/modules/eforms/eform-xlsx-report/eform-xlsx-report.module.ts
@@ -1,18 +1,18 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {
   EformXlsxReportContainerComponent,
   EformXlsxReportHeaderComponent,
 } from './components';
-import { TranslateModule } from '@ngx-translate/core';
-import { EformSharedModule } from 'src/app/common/modules/eform-shared/eform-shared.module';
-import { RouterModule } from '@angular/router';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { OwlDateTimeModule } from '@danielmoncada/angular-datetime-picker';
-import { EformXlsxReportRouting } from './eform-xlsx-report.routing';
+import {TranslateModule} from '@ngx-translate/core';
+import {EformSharedModule} from 'src/app/common/modules/eform-shared/eform-shared.module';
+import {RouterModule} from '@angular/router';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {EformXlsxReportRouting} from './eform-xlsx-report.routing';
 import {MatInputModule} from '@angular/material/input';
 import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
+import {MatDatepickerModule} from '@angular/material/datepicker';
 
 @NgModule({
   declarations: [
@@ -25,12 +25,13 @@ import {MatButtonModule} from '@angular/material/button';
     EformSharedModule,
     RouterModule,
     ReactiveFormsModule,
-    OwlDateTimeModule,
     EformXlsxReportRouting,
     FormsModule,
     MatInputModule,
     MatIconModule,
     MatButtonModule,
+    MatDatepickerModule,
   ],
 })
-export class EformXlsxReportModule {}
+export class EformXlsxReportModule {
+}

--- a/eform-client/src/app/modules/eforms/eforms.module.ts
+++ b/eform-client/src/app/modules/eforms/eforms.module.ts
@@ -22,7 +22,6 @@ import {persistProvider} from 'src/app/modules/eforms/store';
 import {EformSharedTagsModule} from 'src/app/common/modules/eform-shared-tags/eform-shared-tags.module';
 import {MatDatepickerModule} from '@angular/material/datepicker';
 import {MatInputModule} from '@angular/material/input';
-import {EformMatDateFnsDateModule} from 'src/app/common/modules/eform-date-adapter/eform-mat-datefns-date-adapter.module';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
@@ -48,7 +47,6 @@ import {MatChipsModule} from '@angular/material/chips';
         EformSharedTagsModule,
         MatDatepickerModule,
         MatInputModule,
-        EformMatDateFnsDateModule,
         MatCheckboxModule,
         MatButtonModule,
         MatIconModule,


### PR DESCRIPTION
This commit refactors the date picker by replacing the owl-date-time library with Angular Material's mat-datepicker. It also adds custom date-fns locales to support Danish formatting. Additionally, it updates helper functions to include type annotations and improves readability by removing unnecessary pauses in selectDateOnDatePicker function.