### PR TITLE
Refactor date selection function to use dynamic year start value

### DIFF
--- a/eform-client/e2e/Helpers/helper-functions.ts
+++ b/eform-client/e2e/Helpers/helper-functions.ts
@@ -57,7 +57,8 @@ export async function selectDateOnDatePicker(
   await selectYearAndMonthButton.waitForClickable({timeout: 20000});
   await selectYearAndMonthButton.click();
   // select year. after select year we can select month
-  const yearForSelect = await $$(`mat-multi-year-view .mat-calendar-body-cell`)[year - 2016];
+  const yearStart = +(await (await $('mat-multi-year-view .mat-calendar-body-cell-content')).getText());
+  const yearForSelect = await $$(`mat-multi-year-view .mat-calendar-body-cell`)[year - yearStart];
   await yearForSelect.waitForClickable({timeout: 20000});
   await yearForSelect.click();
   // select month. after select month we can select day


### PR DESCRIPTION
This commit refactors the selectDateOnDatePicker function in helper-functions.ts to use a dynamic year start value instead of a hardcoded one. The new implementation uses the first displayed year on the date picker as the starting point for selecting a specific year, making it more flexible and adaptable to changes in the UI.