### PR TITLE
Fix footer covers elements of side menu

### DIFF
--- a/eform-client/src/app/components/footer/footer.component.scss
+++ b/eform-client/src/app/components/footer/footer.component.scss
@@ -24,10 +24,10 @@ span {
 }
 
 .stick-down {
-  left: 0;
-  bottom: 0;
+  //left: 0;
+  //bottom: 0;
   width: 100%;
-  position: absolute;
+  //position: absolute;
 }
 
 .footer-version {

--- a/eform-client/src/app/components/layouts/full-layout/full-layout.component.scss
+++ b/eform-client/src/app/components/layouts/full-layout/full-layout.component.scss
@@ -9,6 +9,12 @@
   }
 }
 
+:host::ng-deep.mat-drawer-inner-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
 #sign-out-dropdown {
   //top: -4px;
 }


### PR DESCRIPTION
The commit fixes an issue where the footer was covering elements of the side menu. The changes include commenting out the left, bottom, and position properties in the .stick-down class in footer.component.scss file. Additionally, in full-layout.component.scss file, the :host::ng-deep.mat-drawer-inner-container selector has been modified to display flex with a column direction and space-between justification.
