### PR TITLE
Fix refresh auth token

### DIFF
--- a/eFormAPI/eFormAPI.Web/Services/AuthService.cs
+++ b/eFormAPI/eFormAPI.Web/Services/AuthService.cs
@@ -165,9 +165,10 @@ public class AuthService : IAuthService
         return new OperationDataResult<EformAuthorizeResult>(true, new EformAuthorizeResult
         {
             Id = user.Id,
-            access_token = token,
-            userName = user.UserName,
-            role = roleList.FirstOrDefault(),
+            AccessToken = token.token,
+            UserName = user.UserName,
+            Role = roleList.FirstOrDefault(),
+            ExpiresIn = token.expireIn,
             FirstName = user.FirstName,
             LastName = user.LastName
         });
@@ -191,13 +192,16 @@ public class AuthService : IAuthService
         return new OperationDataResult<EformAuthorizeResult>(true, new EformAuthorizeResult
         {
             Id = user.Id,
-            access_token = token,
-            userName = user.UserName,
-            role = roleList.FirstOrDefault()
+            AccessToken = token.token,
+            UserName = user.UserName,
+            Role = roleList.FirstOrDefault(),
+            ExpiresIn = token.expireIn,
+            FirstName = user.FirstName,
+            LastName = user.LastName
         });
     }
 
-    public async Task<string> GenerateToken(EformUser user)
+    public async Task<(string token, DateTime expireIn)> GenerateToken(EformUser user)
     {
         if (user != null)
         {
@@ -205,8 +209,8 @@ public class AuthService : IAuthService
             var claims = new List<Claim>
             {
                 new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
-                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-                new Claim(AuthConsts.ClaimLastUpdateKey, timeStamp.ToString())
+                new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+                new(AuthConsts.ClaimLastUpdateKey, timeStamp.ToString())
             };
 
             if (!string.IsNullOrEmpty(user.Locale))
@@ -247,16 +251,17 @@ public class AuthService : IAuthService
 
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_tokenOptions.Value.SigningKey));
             var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            var expireIn = DateTime.Now.AddHours(24);
             var token = new JwtSecurityToken(_tokenOptions.Value.Issuer,
                 _tokenOptions.Value.Issuer,
                 claims.ToArray(),
-                expires: DateTime.Now.AddHours(24),
+                expires: expireIn,
                 signingCredentials: credentials);
 
-            return new JwtSecurityTokenHandler().WriteToken(token);
+            return (new JwtSecurityTokenHandler().WriteToken(token), expireIn);
         }
 
-        return null;
+        return (null, DateTime.Now);
     }
 
 

--- a/eform-client/src/app/common/guards/admin.guard.ts
+++ b/eform-client/src/app/common/guards/admin.guard.ts
@@ -1,10 +1,9 @@
 import {inject, Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivateFn, Router, RouterStateSnapshot} from '@angular/router';
-import { AuthStateService } from 'src/app/common/store';
 import {Observable, take} from 'rxjs';
 import {map, switchMap, tap} from 'rxjs/operators';
 import {Store} from '@ngrx/store';
-import {selectAuthIsAuth, selectCurretnUserClaims} from 'src/app/state/auth/auth.selector';
+import {selectAuthIsAuth} from 'src/app/state';
 
 @Injectable()
 export class AdminGuard {

--- a/eform-client/src/app/common/guards/claims.guard.ts
+++ b/eform-client/src/app/common/guards/claims.guard.ts
@@ -5,7 +5,7 @@ import {
 } from '@angular/router';
 import {UserClaimsEnum} from 'src/app/common/const';
 import {
-  selectCurretnUserClaims
+  selectCurrentUserClaims,
 } from 'src/app/state';
 import {Store} from '@ngrx/store';
 import {UserClaimsModel} from 'src/app/common/models';
@@ -14,7 +14,7 @@ import {UserClaimsModel} from 'src/app/common/models';
 export class ClaimsGuard {
 
   private claims: UserClaimsModel;
-  private selectCurrentUserClaims$ = this.store.select(selectCurretnUserClaims);
+  private selectCurrentUserClaims$ = this.store.select(selectCurrentUserClaims);
 
   constructor(
     private store: Store

--- a/eform-client/src/app/common/guards/permission.guard.ts
+++ b/eform-client/src/app/common/guards/permission.guard.ts
@@ -3,15 +3,14 @@ import {
   ActivatedRouteSnapshot, CanActivateFn,
   RouterStateSnapshot,
 } from '@angular/router';
-import { AuthStateService } from 'src/app/common/store';
 import {Observable, take} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {
   selectAuthIsAuth,
   selectAuthIsLoading,
   selectAuthIsSuccess,
-  selectCurretnUserClaims
-} from 'src/app/state/auth/auth.selector';
+  selectCurrentUserClaims
+} from 'src/app/state';
 import {Store} from '@ngrx/store';
 
 @Injectable()
@@ -19,7 +18,7 @@ export class PermissionGuard {
   private selectAuthIsLoading$ = this.store.select(selectAuthIsLoading);
   private selectAuthIsSuccess$ = this.store.select(selectAuthIsSuccess);
   public selectIsAuth$ = this.store.select(selectAuthIsAuth);
-  private selectCurrentUserClaims$ = this.store.select(selectCurretnUserClaims);
+  private selectCurrentUserClaims$ = this.store.select(selectCurrentUserClaims);
   constructor(
     private store: Store
   ) {

--- a/eform-client/src/app/common/models/auth/auth-response.model.ts
+++ b/eform-client/src/app/common/models/auth/auth-response.model.ts
@@ -1,7 +1,7 @@
 export class AuthResponseModel {
-  access_token: string;
-  token_type: string;
-  expires_in: number;
+  accessToken: string;
+  tokenType: string;
+  expiresIn: Date;
   role: string;
   firstName: string;
   lastName: string;
@@ -9,9 +9,9 @@ export class AuthResponseModel {
   id: number;
 
   constructor(user: any) {
-    this.access_token = user.access_token;
-    this.token_type = user.token_type;
-    this.expires_in = user.expires_in;
+    this.accessToken = user.accessToken;
+    this.tokenType = user.tokenType;
+    this.expiresIn = user.expiresIn;
     this.role = user.role;
     this.firstName = user.firstName;
     this.lastName = user.lastName;

--- a/eform-client/src/app/common/services/auth/locale.service.ts
+++ b/eform-client/src/app/common/services/auth/locale.service.ts
@@ -4,12 +4,7 @@ import {CookieService} from 'ngx-cookie-service';
 import {Observable} from 'rxjs';
 import {OperationDataResult} from 'src/app/common/models';
 import {applicationLanguages} from 'src/app/common/const';
-import {AuthStateService} from 'src/app/common/store';
 import {ApiBaseService} from 'src/app/common/services';
-import {translates} from 'src/assets/i18n/translates';
-import {filter} from 'rxjs/operators';
-import {Store} from '@ngrx/store';
-import {selectCurrentUserLocale} from 'src/app/state/auth/auth.selector';
 
 export let LocaleMethods = {
   // GoogleAuthenticatorInfo: 'api/auth/google-auth-info',
@@ -94,7 +89,6 @@ export class LocaleService {
   }
 
   buildCookieValue(locale: string) {
-    console.log('LocaleService - buildCookieValue');
     return 'c=' + locale + '|uic=' + locale;
   }
 

--- a/eform-client/src/app/components/navigation/navigation.component.ts
+++ b/eform-client/src/app/components/navigation/navigation.component.ts
@@ -17,11 +17,8 @@ import {NestedTreeControl} from '@angular/cdk/tree';
 import {Router} from '@angular/router';
 import {filter, map} from 'rxjs/operators';
 import {Store} from '@ngrx/store';
-import {leftAppMenus} from 'src/app/state/app-menu/app-menu.selector';
-import {AppMenuState} from 'src/app/state/app-menu/app-menu.reducer';
-import {selectAuthIsAuth, selectCurretnUserClaims} from 'src/app/state/auth/auth.selector';
-import {snakeToCamel} from "src/app/common/helpers";
-import {loadAppMenu} from 'src/app/state';
+import {selectAuthIsAuth, selectCurrentUserClaims, leftAppMenus, loadAppMenu} from 'src/app/state';
+import {snakeToCamel} from 'src/app/common/helpers';
 
 interface MenuNode {
   name: string;
@@ -52,7 +49,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
   getCurrentUserInfoSub$: Subscription;
   public allAppMenus$ = this.authStore.select(leftAppMenus);
   private selectAuthIsAuth$ = this.authStore.select(selectAuthIsAuth);
-  private selectCurrentUserClaims$ = this.authStore.select(selectCurretnUserClaims);
+  private selectCurrentUserClaims$ = this.authStore.select(selectCurrentUserClaims);
 
   constructor(
     private adminService: AdminService,

--- a/eform-client/src/app/modules/auth/components/auth/login/login.component.ts
+++ b/eform-client/src/app/modules/auth/components/auth/login/login.component.ts
@@ -21,6 +21,8 @@ import {AutoUnsubscribe} from 'ngx-auto-unsubscribe';
 import {Subscription, take} from 'rxjs';
 import {TitleService} from 'src/app/common/services';
 import {TranslateService} from '@ngx-translate/core';
+import {Store} from '@ngrx/store';
+import {selectAuthIsAuth} from 'src/app/state';
 
 @AutoUnsubscribe()
 @Component({
@@ -42,6 +44,7 @@ export class LoginComponent implements OnInit, OnDestroy {
   showAdminResetForm = false;
   error: string;
   isAuthAsyncSub$: Subscription;
+  private selectIsAuth$ = this.store.select(selectAuthIsAuth);
 
   constructor(
     private router: Router,
@@ -54,6 +57,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     private authStateService: AuthStateService,
     private titleService: TitleService,
     private translateService: TranslateService,
+    private store: Store,
   ) {}
 
   login() {
@@ -93,10 +97,9 @@ export class LoginComponent implements OnInit, OnDestroy {
       username: ['', Validators.required],
       password: ['', Validators.required],
     });
-    // TODO: Fix this
-    // this.isAuthAsyncSub$ = this.authStateService.isAuthAsync.pipe(filter((isAuth: boolean) => isAuth === true)).subscribe(() => {
-    //   this.router.navigate(['/']).then();
-    // });
+    this.isAuthAsyncSub$ = this.selectIsAuth$.pipe(filter((isAuth: boolean) => isAuth === true)).subscribe(() => {
+      this.router.navigate(['/']).then();
+    });
   }
 
   ngOnDestroy(): void {

--- a/eform-client/src/app/state/auth/auth.actions.ts
+++ b/eform-client/src/app/state/auth/auth.actions.ts
@@ -20,30 +20,37 @@ export const updateUserLocale = createAction(
   '[Auth] Update User Locale',
   (payload: any) => ({payload})
 );
+
 export const updateCurrentUserLocaleAndDarkTheme = createAction(
   '[Auth] Update Current User Locale And Dark Theme',
   (payload: any) => ({payload})
 );
+
 export const updateDarkTheme = createAction(
   '[Auth] Update Dark Theme',
   (payload: any) => ({payload})
 );
+
 export const updateUserInfo = createAction(
   '[Auth] Update User Info',
   (payload: { userSettings: OperationDataResult<UserSettingsModel>, userClaims: UserClaimsModel }) => ({payload})
 );
+
 export const updateSideMenuOpened = createAction(
   '[Auth] Update Side Menu Opened',
   (payload: { sideMenuIsOpened: boolean }) => ({payload})
 );
-export const ConnectionStringExist = createAction(
+
+export const connectionStringExist = createAction(
   '[Auth] Connection String Exist',
   (payload: any) => ({payload})
 );
+
 export const connectionStringExistCount = createAction(
   '[Auth] Connection String Exist Count',
   (payload: { isConnectionStringExist: boolean, count: number }) => ({payload})
 );
+
 export const loadAuthSuccess = createAction(
   '[Auth] Authenticate Success',
   (payload: { token: AuthToken, currentUser: AuthCurrentUser, count: number }) => ({payload})

--- a/eform-client/src/app/state/auth/auth.effects.ts
+++ b/eform-client/src/app/state/auth/auth.effects.ts
@@ -2,69 +2,122 @@ import {Injectable} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
 import {AdminService, AppSettingsService, AuthService} from 'src/app/common/services';
 import {exhaustMap, of, catchError, map} from 'rxjs';
-import {loadAuthFailure, loadAuthSuccess, refreshToken,} from 'src/app/state';
+import {authenticate, loadAuthFailure, loadAuthState, loadAuthSuccess, refreshToken,} from 'src/app/state';
 import {AuthResponseModel, OperationDataResult} from 'src/app/common/models';
+import {AuthStateService} from 'src/app/common/store';
 
 @Injectable()
 export class AuthEffects {
-  constructor(private actions$: Actions,
-              private settingsService: AppSettingsService,
-              private adminService: AdminService,
-              private authService: AuthService) {
+  constructor(
+    private actions$: Actions,
+    private settingsService: AppSettingsService,
+    private adminService: AdminService,
+    private authService: AuthService,
+    private authStateService: AuthStateService,
+  ) {
   }
 
   authenticate$ = createEffect(() => this.actions$.pipe(
-    ofType('[Auth] Authenticate'),
-    exhaustMap((action) => this.authService.login(action)
-      .pipe(
-        map((auth: any) => loadAuthSuccess(auth)),
-        catchError((error: any) => of(loadAuthFailure(error)))
-      ))
+      ofType(authenticate),
+      exhaustMap((action) => this.authService.login(action.payload)
+        .pipe(
+          map((auth: AuthResponseModel) => loadAuthSuccess({
+            token: {
+              accessToken: auth.accessToken,
+              tokenType: auth.tokenType,
+              role: auth.role,
+              expiresIn: auth.expiresIn,
+            },
+            currentUser: {
+              id: auth.id,
+              userName: auth.userName,
+              firstName: auth.firstName,
+              lastName: auth.lastName,
+            },
+            count: 2,
+          })),
+          catchError((error: any) => of(loadAuthFailure(error)))
+        ))
     )
   );
 
   refreshToken$ = createEffect(() => this.actions$.pipe(
-    ofType(refreshToken),
-    exhaustMap((action) => this.authService.refreshToken()
-      .pipe(
-        map((auth: OperationDataResult<AuthResponseModel>) => (loadAuthSuccess({
-          token: {
-            accessToken: auth.model.access_token,
-            tokenType: auth.model.token_type,
-            role: auth.model.role,
-            expiresIn: auth.model.expires_in,
-          },
-          currentUser: {
-            id: auth.model.id,
-            userName: auth.model.userName,
-            firstName: auth.model.firstName,
-            lastName: auth.model.lastName,
-          },
-          count: 2,
-        }))),
-        catchError((error: any) => of(loadAuthFailure(error)))
-      ))
+      ofType(refreshToken),
+      exhaustMap((action) => this.authService.refreshToken()
+        .pipe(
+          map((auth: OperationDataResult<AuthResponseModel>) => (loadAuthSuccess({
+            token: {
+              accessToken: auth.model.accessToken,
+              tokenType: auth.model.tokenType,
+              role: auth.model.role,
+              expiresIn: auth.model.expiresIn,
+            },
+            currentUser: {
+              id: auth.model.id,
+              userName: auth.model.userName,
+              firstName: auth.model.firstName,
+              lastName: auth.model.lastName,
+            },
+            count: 2,
+          }))),
+          catchError((error: any) => of(loadAuthFailure(error)))
+        ))
     )
   );
 
   updateConnectionString$ = createEffect(() => this.actions$.pipe(
-    ofType('[Auth] Update Connection String'),
-    exhaustMap((action) => this.settingsService.updateConnectionString(action)
-      .pipe(
-        map((auth: any) => ({type: '[Auth] Update Connection String Success', payload: auth})),
-        catchError((error: any) => of({type: '[Auth] Update Connection String Failure', payload: error}))
-      ))
+      ofType('[Auth] Update Connection String'),
+      exhaustMap((action) => this.settingsService.updateConnectionString(action)
+        .pipe(
+          map((auth: any) => ({type: '[Auth] Update Connection String Success', payload: auth})),
+          catchError((error: any) => of({type: '[Auth] Update Connection String Failure', payload: error}))
+        ))
     )
   );
 
   loadUserInformation$ = createEffect(() => this.actions$.pipe(
-    ofType('[Auth] Load User Information'),
-    exhaustMap(() => this.adminService.getCurrentUserInfo()
-      .pipe(
-        map((auth: any) => ({type: '[Auth] Load User Information Success', payload: auth})),
-        catchError((error: any) => of({type: '[Auth] Load User Information Failure', payload: error}))
-      ))
+      ofType('[Auth] Load User Information'),
+      exhaustMap(() => this.adminService.getCurrentUserInfo()
+        .pipe(
+          map((auth: any) => ({type: '[Auth] Load User Information Success', payload: auth})),
+          catchError((error: any) => of({type: '[Auth] Load User Information Failure', payload: error}))
+        ))
     )
   );
+  /*after load token from localStorage check expireIn toke and if tokes is expire - refresh token.
+  loadAuthState need run before ALL app and one time*/
+  loadAuthState$ = createEffect(() => this.actions$.pipe(
+    ofType(loadAuthState),
+    exhaustMap((action) => {
+      if (
+        action.payload &&
+        action.payload.state &&
+        action.payload.state.token &&
+        action.payload.state.token.expiresIn &&
+        action.payload.state.token.expiresIn > new Date()
+      ) {
+        return this.authService.refreshToken().pipe(
+          map((auth: OperationDataResult<AuthResponseModel>) => (loadAuthSuccess({
+            token: {
+              accessToken: auth.model.accessToken,
+              tokenType: auth.model.tokenType,
+              role: auth.model.role,
+              expiresIn: auth.model.expiresIn,
+            },
+            currentUser: {
+              id: auth.model.id,
+              userName: auth.model.userName,
+              firstName: auth.model.firstName,
+              lastName: auth.model.lastName,
+            },
+            count: 2,
+          }))),
+          catchError((error: any) => {
+            this.authStateService.logout();
+            return of(loadAuthFailure(error));
+          }));
+      }
+    })
+  ));
 
 }

--- a/eform-client/src/app/state/auth/auth.recuder.ts
+++ b/eform-client/src/app/state/auth/auth.recuder.ts
@@ -11,7 +11,7 @@ import {
 } from './';
 import {StoreStatusEnum} from 'src/app/common/const';
 
-export const AUTH_REDUCER_NODE = 'auth';
+export const AUTH_REDUCER_NODE: string = 'auth';
 
 export interface AuthCurrentUser {
   firstName: string;
@@ -27,7 +27,7 @@ export interface AuthCurrentUser {
 
 export interface AuthToken {
   accessToken: string;
-  expiresIn: any;
+  expiresIn: Date;
   tokenType: string;
   role: string;
 }
@@ -47,7 +47,7 @@ export interface AuthState {
 export const authInitialState: AuthState = {
   token: {
     accessToken: '',
-    expiresIn: '',
+    expiresIn: null,
     tokenType: '',
     role: '',
   },
@@ -122,8 +122,8 @@ export const authInitialState: AuthState = {
 const _authReducer = createReducer(
   authInitialState,
   on(authenticate, (state) => ({
-    ...state,
-    status: StoreStatusEnum.Loading,
+      ...state,
+      status: StoreStatusEnum.Loading,
     }),
   ),
   on(connectionStringExistCount, (state, {payload}) => ({
@@ -133,18 +133,21 @@ const _authReducer = createReducer(
       isConnectionStringExist: payload.isConnectionStringExist,
       count: payload.count,
     },
-    })),
+  })),
   on(loadAuthSuccess, (state, {payload}) => ({
     ...state,
     status: StoreStatusEnum.Success,
     error: null,
     token: payload.token,
-    currentUser: payload.currentUser,
+    currentUser: {
+      ...state.currentUser,
+      ...payload.currentUser
+    },
     connectionString: {
       isConnectionStringExist: true,
       count: payload.count,
     },
-    })),
+  })),
   on(updateUserInfo, (state, {payload}) => ({
     ...state,
     status: StoreStatusEnum.Success,
@@ -171,18 +174,23 @@ const _authReducer = createReducer(
     ...state,
     error: payload,
     status: StoreStatusEnum.Error,
-    })),
+  })),
   on(loadAuthState, (_, {payload}) => ({
     ...payload.state,
   })),
   on(logout, () => ({
     ...authInitialState
   })),
+  on(refreshToken, (state) => ({
+    ...state,
+    status: StoreStatusEnum.Loading,
+  })),
   on(updateSideMenuOpened, (state, {payload}) => ({
     ...state,
     sideMenuOpened: payload.sideMenuIsOpened,
   })),
 );
+
 export function authReducer(state: AuthState | undefined, action: any) {
   return _authReducer(state, action);
 }

--- a/eform-client/src/app/state/auth/auth.selector.ts
+++ b/eform-client/src/app/state/auth/auth.selector.ts
@@ -1,6 +1,6 @@
 import {createFeatureSelector, createSelector} from '@ngrx/store';
 import {AUTH_REDUCER_NODE, AuthState} from 'src/app/state/auth/auth.recuder';
-import {AppState} from 'src/app/state/app.state';
+import {AppState} from 'src/app/state';
 
 export const authFeatureSelector = createFeatureSelector<AuthState>(AUTH_REDUCER_NODE);
 
@@ -12,124 +12,124 @@ export const selectAuthIsLoading
   = createSelector(selectAuth, (state: AuthState) => state.status === 'loading');
 export const selectAuthIsSuccess
   = createSelector(selectAuth, (state: AuthState) => state.status === 'success');
+export const selectAuthToken
+  = createSelector(selectAuth, (state: AuthState) => state.token);
 export const selectAuthIsAuth
-  = createSelector(selectAuth, (state: AuthState) => state.token.accessToken !== '');
+  = createSelector(selectAuth, (state: AuthState) => state.token && state.token.accessToken && state.token.accessToken !== '');
 export const selectBearerToken
-  = createSelector(selectAuth, (state: AuthState) => state.token.accessToken);
+  = createSelector(selectAuthToken, (state) => state.accessToken);
 export const selectAuthUser
   = createSelector(selectAuth, (state: AuthState) => state.currentUser);
 export const selectAuthError
   = createSelector(selectAuth, (state: AuthState) => state.error);
-export const selectConnectionStringExists
-  = createSelector(selectAuth, (state: AuthState) => state.connectionString.isConnectionStringExist);
 export const selectConnectionStringWithCount
   = createSelector(selectAuth, (state: AuthState) => state.connectionString);
+export const selectConnectionStringExists
+  = createSelector(selectConnectionStringWithCount, (state) => state.isConnectionStringExist);
 export const selectLoginRedirectUrl
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.loginRedirectUrl);
+  = createSelector(selectAuthUser, (state) => state.loginRedirectUrl);
 export const selectSideMenuOpened
   = createSelector(selectAuth, (state: AuthState) => state.sideMenuOpened);
 export const selectIsDarkMode
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.darkTheme);
+  = createSelector(selectAuthUser, (state) => state.darkTheme);
 export const selectCurrentUserLocale
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.locale);
+  = createSelector(selectAuthUser, (state) => state.locale);
 export const selectCurrentUserLanguageId
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.languageId);
+  = createSelector(selectAuthUser, (state) => state.languageId);
 export const selectCurrentUserName
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.userName);
+  = createSelector(selectAuthUser, (state) => state.userName);
 export const selectCurrentUserFullName
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.firstName + ' ' + state.currentUser.lastName);
+  = createSelector(selectAuthUser, (state) => `${state.firstName} ${state.lastName}`);
 export const selectCurrentUserIsAdmin
-  = createSelector(selectAuth, (state: AuthState) => state.token.role === 'Admin');
-export const selectCurretnUserClaims
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims);
-export const selectCurrentUserClaimsUsersUpdate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.usersUpdate);
-export const selectCurrentUserClaimsUsersDelete
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.usersDelete);
-export const selectCurrentUserClaimsUsersCreate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.usersCreate);
+  = createSelector(selectAuthToken, (state) => state.role === 'Admin');
 export const selectCurrentUserClaims
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims);
+  = createSelector(selectAuthUser, (state) => state.claims);
+export const selectCurrentUserClaimsUsersUpdate
+  = createSelector(selectCurrentUserClaims, (state) => state.usersUpdate);
+export const selectCurrentUserClaimsUsersDelete
+  = createSelector(selectCurrentUserClaims, (state) => state.usersDelete);
+export const selectCurrentUserClaimsUsersCreate
+  = createSelector(selectCurrentUserClaims, (state) => state.usersCreate);
 export const selectCurrentUserClaimsCaseUpdate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.caseUpdate);
+  = createSelector(selectCurrentUserClaims, (state) => state.caseUpdate);
 export const selectCaseDelete
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.caseDelete);
+  = createSelector(selectCurrentUserClaims, (state) => state.caseDelete);
 export const selectCaseGetPdf
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.caseGetPdf);
+  = createSelector(selectCurrentUserClaims, (state) => state.caseGetPdf);
 export const selectCaseGetDocx
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.caseGetDocx);
+  = createSelector(selectCurrentUserClaims, (state) => state.caseGetDocx);
 export const selectCaseGetPptx
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.caseGetPptx);
+  = createSelector(selectCurrentUserClaims, (state) => state.caseGetPptx);
 export const selectCurrentUserClaimsUnitsRead
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.unitsRead);
+  = createSelector(selectCurrentUserClaims, (state) => state.unitsRead);
 export const selectCurrentUserClaimsUnitsUpdate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.unitsUpdate);
+  = createSelector(selectCurrentUserClaims, (state) => state.unitsUpdate);
 export const selectCurrentUserClaimsSitesCreate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.sitesCreate);
+  = createSelector(selectCurrentUserClaims, (state) => state.sitesCreate);
 export const selectCurrentUserClaimsSitesRead
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.sitesRead);
+  = createSelector(selectCurrentUserClaims, (state) => state.sitesRead);
 export const selectCurrentUserClaimsSitesUpdate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.sitesUpdate);
+  = createSelector(selectCurrentUserClaims, (state) => state.sitesUpdate);
 export const selectCurrentUserClaimsSitesDelete
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.sitesDelete);
+  = createSelector(selectCurrentUserClaims, (state) => state.sitesDelete);
 export const selectCurrentUserClaimsWorkersCreate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.workersCreate);
+  = createSelector(selectCurrentUserClaims, (state) => state.workersCreate);
 export const selectCurrentUserClaimsWorkersRead
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.workersRead);
+  = createSelector(selectCurrentUserClaims, (state) => state.workersRead);
 export const selectCurrentUserClaimsWorkersUpdate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.workersUpdate);
+  = createSelector(selectCurrentUserClaims, (state) => state.workersUpdate);
 export const selectCurrentUserClaimsWorkersDelete
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.workersDelete);
+  = createSelector(selectCurrentUserClaims, (state) => state.workersDelete);
 export const selectCurrentUserClaimsEntitySearchCreate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.entitySearchCreate);
+  = createSelector(selectCurrentUserClaims, (state) => state.entitySearchCreate);
 export const selectCurrentUserClaimsEntitySearchRead
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.entitySearchRead);
+  = createSelector(selectCurrentUserClaims, (state) => state.entitySearchRead);
 export const selectCurrentUserClaimsEntitySearchUpdate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.entitySearchUpdate);
+  = createSelector(selectCurrentUserClaims, (state) => state.entitySearchUpdate);
 export const selectCurrentUserClaimsEntitySearchDelete
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.entitySearchDelete);
+  = createSelector(selectCurrentUserClaims, (state) => state.entitySearchDelete);
 export const selectCurrentUserClaimsEntitySelectCreate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.entitySelectCreate);
+  = createSelector(selectCurrentUserClaims, (state) => state.entitySelectCreate);
 export const selectCurrentUserClaimsEntitySelectRead
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.entitySelectRead);
+  = createSelector(selectCurrentUserClaims, (state) => state.entitySelectRead);
 export const selectCurrentUserClaimsEntitySelectUpdate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.entitySelectUpdate);
+  = createSelector(selectCurrentUserClaims, (state) => state.entitySelectUpdate);
 export const selectCurrentUserClaimsEntitySelectDelete
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.entitySelectDelete);
+  = createSelector(selectCurrentUserClaims, (state) => state.entitySelectDelete);
 export const selectCurrentUserClaimsEformsCreate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsCreate);
+  = createSelector(selectCurrentUserClaims, (state) => state.eformsCreate);
 export const selectEformAllowManagingEformTags
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformAllowManagingEformTags);
+  = createSelector(selectCurrentUserClaims, (state) => state.eformAllowManagingEformTags);
 export const selectCurrentUserClaimsDeviceUsersRead
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.deviceUsersRead);
+  = createSelector(selectCurrentUserClaims, (state) => state.deviceUsersRead);
 export const selectCurrentUserClaimsDeviceUsersUpdate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.deviceUsersUpdate);
+  = createSelector(selectCurrentUserClaims, (state) => state.deviceUsersUpdate);
 export const selectCurrentUserClaimsDeviceUsersDelete
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.deviceUsersDelete);
+  = createSelector(selectCurrentUserClaims, (state) => state.deviceUsersDelete);
 export const selectCurrentUserClaimsDeviceUsersCreate
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.deviceUsersCreate);
+  = createSelector(selectCurrentUserClaims, (state) => state.deviceUsersCreate);
 export const selectCurrentUserClaimsEformsRead
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsRead);
+  = createSelector(selectCurrentUserClaims, (state) => state.eformsRead);
 export const selectCurrentUserClaimsEformsDelete
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsDelete);
+  = createSelector(selectCurrentUserClaims, (state) => state.eformsDelete);
 export const selectCurrentUserClaimsEformsUpdateColumns
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsUpdateColumns);
+  = createSelector(selectCurrentUserClaims, (state) => state.eformsUpdateColumns);
 export const selectCurrentUserClaimsEformsDownloadXml =
-  createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsDownloadXml);
+  createSelector(selectCurrentUserClaims, (state) => state.eformsDownloadXml);
 export const selectCurrentUserClaimsEformsUploadZip =
-  createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsUploadZip);
+  createSelector(selectCurrentUserClaims, (state) => state.eformsUploadZip);
 export const selectCurrentUserClaimsEformsPairingUpdate =
-  createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsPairingUpdate);
+  createSelector(selectCurrentUserClaims, (state) => state.eformsPairingUpdate);
 export const selectCurrentUserClaimsEformsUpdateTags =
-  createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsUpdateTags);
+  createSelector(selectCurrentUserClaims, (state) => state.eformsUpdateTags);
 export const selectCurrentUserClaimsEformsPairingRead
-  = createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsPairingRead);
+  = createSelector(selectCurrentUserClaims, (state) => state.eformsPairingRead);
 export const selectCurrentUserClaimsEformsReadTags =
-  createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsReadTags);
+  createSelector(selectCurrentUserClaims, (state) => state.eformsReadTags);
 export const selectCurrentUserClaimsEformsGetCsv =
-  createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsGetCsv);
+  createSelector(selectCurrentUserClaims, (state) => state.eformsGetCsv);
 export const selectCurrentUserClaimsEformsReadJasperReport =
-  createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsReadJasperReport);
+  createSelector(selectCurrentUserClaims, (state) => state.eformsReadJasperReport);
 export const selectCurrentUserClaimsEformsUpdateJasperReport =
-  createSelector(selectAuth, (state: AuthState) => state.currentUser.claims.eformsUpdateJasperReport);
+  createSelector(selectCurrentUserClaims, (state) => state.eformsUpdateJasperReport);
 


### PR DESCRIPTION
The commit fixes the following issues:
- Fixed import statements in admin.guard.ts, claims.guard.ts, and permission.guard.ts
- Renamed variables in auth-response.model.ts to follow camel case convention
- Removed unused imports and commented code in http-error.interceptor.ts
- Removed unused imports and console.log statement in locale.service.ts
- Removed unused imports and fixed formatting in auth-state.service.ts
