### PR TITLE
Add SdkCaseId to calendar task response

### DIFF
--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Infrastructure/Models/Calendar/CalendarTaskResponseModel.cs
@@ -26,5 +26,6 @@ public class CalendarTaskResponseModel
     public bool IsAllDay { get; set; }
     public int? ExceptionId { get; set; }
     public int? EformId { get; set; }
+    public int? SdkCaseId { get; set; }
     public int? ItemPlanningTagId { get; set; }
 }

--- a/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
+++ b/eFormAPI/Plugins/BackendConfiguration.Pn/BackendConfiguration.Pn/Services/BackendConfigurationCalendarService/BackendConfigurationCalendarService.cs
@@ -372,6 +372,7 @@ public class BackendConfigurationCalendarService(
                     PlanningId = compliance.PlanningId,
                     IsAllDay = compIsAllDay,
                     EformId = arp?.AreaRule?.EformId,
+                    SdkCaseId = compliance.MicrotingSdkCaseId,
                     ItemPlanningTagId = arp?.ItemPlanningTagId
                 };
 


### PR DESCRIPTION
## Summary
- Add `SdkCaseId` property to `CalendarTaskResponseModel`
- Map `compliance.MicrotingSdkCaseId` in calendar service for compliance-sourced tasks
- Enables Flutter app to call `ReadComplianceCase` with the SDK case ID

## Test plan
- [ ] Verify `GetTasksForWeek` returns `sdk_case_id` for compliance tasks
- [ ] Verify `ReadComplianceCase` can be called with the returned IDs
- [ ] Verify non-compliance tasks have `sdk_case_id = 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)