### PR TITLE
fix(grpc): dedupe Unimplemented service endpoints causing AmbiguousMatchException

### DIFF
--- a/eFormAPI/eFormAPI.Web/Hosting/DeduplicateUnimplementedGrpcMatcherPolicy.cs
+++ b/eFormAPI/eFormAPI.Web/Hosting/DeduplicateUnimplementedGrpcMatcherPolicy.cs
@@ -1,0 +1,95 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2021 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+
+namespace eFormAPI.Web.Hosting;
+
+/// <summary>
+/// When multiple plugins call <c>services.AddGrpc()</c> (each plugin needs
+/// its own call so its <c>MapGrpcService&lt;T&gt;</c> validation passes),
+/// each registration adds a catch-all "Unimplemented service" endpoint
+/// to the host's shared endpoint table. Three plugins => three duplicates =>
+/// <c>AmbiguousMatchException</c> on any unmapped gRPC route.
+///
+/// This policy runs at endpoint selection time and invalidates all but
+/// one duplicate so the request gets a clean gRPC <c>UNIMPLEMENTED</c>
+/// status (status code 12) instead of HTTP 500.
+///
+/// The DisplayName string ("gRPC - Unimplemented service") is set by
+/// <c>Grpc.AspNetCore.Server</c> in
+/// <c>ServiceRouteBuilder.CreateUnimplementedEndpoint</c>.
+/// </summary>
+public sealed class DeduplicateUnimplementedGrpcMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
+{
+    private const string UnimplementedMarker = "Unimplemented service";
+
+    public override int Order => -100;
+
+    public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
+    {
+        var seen = false;
+        foreach (var endpoint in endpoints)
+        {
+            if (IsUnimplemented(endpoint))
+            {
+                if (seen) return true;
+                seen = true;
+            }
+        }
+        return false;
+    }
+
+    public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
+    {
+        var keptOne = false;
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            if (!candidates.IsValidCandidate(i)) continue;
+            var endpoint = candidates[i].Endpoint;
+            if (!IsUnimplemented(endpoint)) continue;
+
+            if (keptOne)
+            {
+                candidates.SetValidity(i, false);
+            }
+            else
+            {
+                keptOne = true;
+            }
+        }
+        return Task.CompletedTask;
+    }
+
+    private static bool IsUnimplemented(Endpoint endpoint)
+    {
+        var displayName = endpoint?.DisplayName;
+        return displayName != null && displayName.Contains(UnimplementedMarker, StringComparison.Ordinal);
+    }
+}

--- a/eFormAPI/eFormAPI.Web/Startup.cs
+++ b/eFormAPI/eFormAPI.Web/Startup.cs
@@ -38,8 +38,10 @@ using Abstractions;
 using Abstractions.Advanced;
 using Abstractions.Eforms;
 using Abstractions.Security;
+using Hosting;
 using Hosting.Extensions;
 using Hosting.Security;
+using Microsoft.AspNetCore.Routing;
 using Infrastructure.Models.Settings.Plugins;
 using Services;
 using Services.Security;
@@ -322,6 +324,11 @@ public class Startup(IConfiguration configuration)
 
         // gRPC
         services.AddGrpc();
+
+        // Each plugin's AddGrpc() call registers a duplicate "Unimplemented service"
+        // fallback endpoint. Multiple duplicates cause AmbiguousMatchException on any
+        // unmapped gRPC route. This policy keeps a single fallback at routing time.
+        services.AddSingleton<MatcherPolicy, DeduplicateUnimplementedGrpcMatcherPolicy>();
 
         // plugins
         services.AddEFormPlugins(Program.EnabledPlugins);


### PR DESCRIPTION
## Summary

- Three host/plugin `AddGrpc()` calls each register a duplicate `gRPC - Unimplemented service` fallback endpoint, producing `AmbiguousMatchException` and HTTP 500 on every unmapped gRPC route.
- Adds `DeduplicateUnimplementedGrpcMatcherPolicy` (an `IEndpointSelectorPolicy`) that invalidates all but one duplicate at endpoint-selection time, restoring the expected gRPC `UNIMPLEMENTED` (status 12) trailers-only response.
- Plugin `AddGrpc()` calls are intentionally left in place — each is structurally required so the plugin's own `MapGrpcService<T>()` DI-scope validation passes; removing them crashes plugin startup with "Unable to find the required services".

## Root cause

`Grpc.AspNetCore.Server.Model.Internal.ServiceRouteBuilder.CreateUnimplementedEndpoint` (verified against package v2.80.0 source) registers an endpoint with `DisplayName = "gRPC - Unimplemented service"` per `AddGrpc()` call. With three callers (host + `BackendConfiguration.Pn` + `TimePlanning.Pn`), the host's shared endpoint table ends up with three identical fallbacks. `EndpointMiddleware` then throws:

```
Microsoft.AspNetCore.Routing.Matching.AmbiguousMatchException:
  The request matched multiple endpoints. Matches:
  gRPC - Unimplemented service / Unimplemented service / Unimplemented service
```

## Verification

Built clean (0 errors, 56 pre-existing warnings). Backend restarted with the policy; sent an unmapped gRPC call:

```
$ curl -s --http2-prior-knowledge -X POST -H "Content-Type: application/grpc" \
    http://localhost:5001/microting.opgaver.Opgaver/StreamOpgaveChanges -D -
HTTP/2 200
content-type: application/grpc
grpc-status: 12
grpc-message: Service is unimplemented.
```

Backend log shows a single clean fallback execution and zero `AmbiguousMatchException` occurrences.

## Discovery

Found via the flutter-eform contract-test harness:
- microting/flutter-eform#716 (harness + proto sync)
- microting/flutter-eform#717 (gRPC dev-seam)
- microting/flutter-eform#718 (initial goldens)

## Test plan

- [x] `dotnet build` clean
- [x] Backend boots with all plugins
- [x] Unmapped gRPC route returns trailers-only `grpc-status: 12` (no HTTP 500, no `AmbiguousMatchException`)
- [ ] CI green on `stable`
- [ ] Manual smoke: implemented gRPC services on the host (Opgaver, etc.) still route correctly (policy is a no-op when only one fallback or zero unimplemented endpoints match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)