### PR TITLE
fix(eform-files): reset stream Position before computing MD5

### DIFF
--- a/eFormAPI/eFormAPI.Web/Controllers/Eforms/EFormFilesController.cs
+++ b/eFormAPI/eFormAPI.Web/Controllers/Eforms/EFormFilesController.cs
@@ -286,6 +286,12 @@ public class EFormFilesController(
                 await using (var stream = new FileStream(filePath, FileMode.Create))
                 {
                     await newFile.CopyToAsync(stream);
+                    // CopyToAsync leaves the stream at EOF; without a rewind,
+                    // ComputeHashAsync reads zero bytes and stores the MD5 of
+                    // empty input (d41d8cd98f00b204e9800998ecf8427e) for every
+                    // upload. Caught by the flutter-eform parity harness photo
+                    // scenario.
+                    stream.Position = 0;
                     var grr = await md5.ComputeHashAsync(stream);
                     hash = BitConverter.ToString(grr).Replace("-", "").ToLower();
                 }


### PR DESCRIPTION
## Summary
- `AddNewImage` in `EFormFilesController` called `CopyToAsync` on the upload `FileStream`, leaving the stream at EOF. The subsequent MD5 computation then read zero bytes and stored `d41d8cd98f00b204e9800998ecf8427e` (the MD5 of empty input) for every uploaded image.
- Fix seeks the stream back to position 0 before hashing so the real content gets hashed.
- Caught by the flutter-eform parity harness photo scenario.

## Context
This commit was previously sitting on `fix/grpc-deduplicate-unimplemented-fallback` alongside the gRPC dedup fix (which already shipped as #7870). Splitting it out so it can land on `stable` on its own.

## Test plan
- [ ] Upload an image via the eform UI and confirm the stored MD5 in the DB matches the file content (not `d41d8cd9…`).
- [ ] Re-run the flutter-eform parity harness photo scenario and confirm MD5 parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)