### PR TITLE
style(eforms): align Mine eForms page with property-workers pattern

### DIFF
--- a/eform-client/cypress/e2e/e/profile-settings.language.spec.cy.ts
+++ b/eform-client/cypress/e2e/e/profile-settings.language.spec.cy.ts
@@ -3,11 +3,11 @@ import profileSettingsPage from '../ProfileSettings.page';
 import { expect } from 'chai';
 
 const translationsEFormsPageEng: Array<{ selector: string; value: string }> = [
-  { selector: 'eform-new-subheader h2', value: 'My eForms' },
+  { selector: 'mat-card.eform-sub-header h2', value: 'My eForms' },
 ];
 
 const translationsEFormsPageDan: Array<{ selector: string; value: string }> = [
-  { selector: 'eform-new-subheader h2', value: 'Mine eForms' },
+  { selector: 'mat-card.eform-sub-header h2', value: 'Mine eForms' },
 ];
 
 describe('Profile Settings - Language', function () {

--- a/eform-client/playwright/e2e/Tests/c/subheader.spec.ts
+++ b/eform-client/playwright/e2e/Tests/c/subheader.spec.ts
@@ -40,7 +40,7 @@ test.describe('Subheader test', () => {
 
   test('must navigate on create menu item and translate must be == translate', async () => {
     await (await myEformsPage.Navbar.clickOnHeaderMenuItem2(translation)).click();
-    const h1 = page.locator('eform-new-subheader h2');
+    const h1 = page.locator('mat-card.eform-sub-header h2');
     expect((await h1.textContent())?.trim()).toBe(translation);
     await myEformsPage.Navbar.goToMenuEditorPage();
     await navigationMenuPage.openOnEditCreatedMenuItem(0);

--- a/eform-client/playwright/e2e/Tests/e/profile-settings.language.spec.ts
+++ b/eform-client/playwright/e2e/Tests/e/profile-settings.language.spec.ts
@@ -4,13 +4,13 @@ import { MyEformsPage } from '../../Page objects/MyEforms.page';
 import { ProfileSettingsPage } from '../../Page objects/ProfileSettings.page';
 
 const translationsEFormsPageEng: Array<{ key: string; value: string }> = [
-  { key: 'eform-new-subheader h2', value: 'My eForms' },
+  { key: 'mat-card.eform-sub-header h2', value: 'My eForms' },
 ];
 const translationsEFormsPageGer: Array<{ key: string; value: string }> = [
-  { key: 'eform-new-subheader h2', value: 'Meine eForms' },
+  { key: 'mat-card.eform-sub-header h2', value: 'Meine eForms' },
 ];
 const translationsEFormsPageDan: Array<{ key: string; value: string }> = [
-  { key: 'eform-new-subheader h2', value: 'Mine eForms' },
+  { key: 'mat-card.eform-sub-header h2', value: 'Mine eForms' },
 ];
 
 test.describe('Profile settings', () => {

--- a/eform-client/src/app/modules/eforms/components/eforms-page/eforms-page.component.html
+++ b/eform-client/src/app/modules/eforms/components/eforms-page/eforms-page.component.html
@@ -1,5 +1,6 @@
-<eform-new-subheader>
-  <div class="d-flex flex-row justify-content-center align-items-center gap-12">
+<mat-card class="eform-sub-header d-flex flex-column gap-12 mb-3 p-3" style="align-items: stretch;">
+  <h2 style="margin: 0">{{ pageTitle | translate }}</h2>
+  <div class="d-flex flex-row flex-wrap align-items-end justify-content-end gap-12">
     <div class="text-field--rounded mt-4">
       <mat-form-field>
         <mat-label>{{ 'Search eForm' | translate }}</mat-label>
@@ -13,7 +14,23 @@
         <mat-icon matSuffix>search</mat-icon>
       </mat-form-field>
     </div>
-    <div class="line-vert"></div>
+    <mat-form-field *ngIf="selectCurrentUserClaimsEformsReadTags$ | async">
+      <mat-label>{{ 'Tags' | translate }}</mat-label>
+      <mtx-select
+        class="custom"
+        [dropdownPosition]="'bottom'"
+        [items]="availableTags"
+        [ngModel]="selectEformsTagIds$ | async"
+        (add)="saveTag($event)"
+        (remove)="removeSavedTag($event)"
+        [clearable]="false"
+        [bindLabel]="'name'"
+        [bindValue]="'id'"
+        id="tagSelector"
+        [multiple]="true"
+      >
+      </mtx-select>
+    </mat-form-field>
     <button
       class="btn-secondary btn-secondary--icon-rounded-border"
       id="importEformsBtn"
@@ -31,7 +48,6 @@
     >
       <mat-icon class="icon-secondary">style</mat-icon>
     </button>
-
     <button
       matTooltip="{{ 'New eForm from XML' | translate }}"
       id="newEFormBtn"
@@ -39,12 +55,8 @@
       (click)="openNewEformModal()"
       class="btn-secondary btn-secondary--icon-rounded-border"
     >
-<!--      <mat-icon class="icon-secondary">text_snippet</mat-icon>-->
       <app-icon name="xmlFile" size="20"></app-icon>
     </button>
-
-    <div class="line-vert"></div>
-
     <button
       id="eformsVisualEditor"
       class="btn-primary btn-primary--icon-left"
@@ -55,44 +67,8 @@
       <span>{{ 'New eForm' | translate }}</span>
     </button>
   </div>
-</eform-new-subheader>
+</mat-card>
 
-<!--Here you can choose approach as you like: container-row, or flex, or just element with required styles and markup-->
-<ng-template #toolbarTpl>
-  <div class="d-flex flex-row justify-content-start flex-nowrap align-items-center gap-12">
-    <div class="d-flex flex-column align-items-end " *ngIf="selectCurrentUserClaimsEformsReadTags$ | async">
-      <mat-form-field >
-        <mat-label>{{ 'Tags' | translate }}</mat-label>
-        <mtx-select
-
-          class="custom"
-          [dropdownPosition]="'bottom'"
-          [items]="availableTags"
-          [ngModel]="selectEformsTagIds$ | async"
-          (add)="saveTag($event)"
-          (remove)="removeSavedTag($event)"
-          [clearable]="false"
-          [bindLabel]="'name'"
-          [bindValue]="'id'"
-          id="tagSelector"
-          [multiple]="true"
-        >
-          <!--          <ng-template ng-label-tmp let-item="item">-->
-          <!--            <mat-chip-list>-->
-          <!--              <mat-chip color="primary" selected (removed)="removeSavedTag({value: {id: item.id}})">-->
-          <!--                {{item.name}}-->
-          <!--              </mat-chip>-->
-          <!--              <button matChipRemove>-->
-          <!--                <mat-icon>cancel</mat-icon>-->
-          <!--              </button>-->
-          <!--            </mat-chip-list>-->
-
-          <!--        </ng-template>-->
-        </mtx-select>
-      </mat-form-field>
-    </div>
-  </div>
-</ng-template>
 <mtx-grid
   id="mainPageEFormsTableBody"
   [data]="templateListModel.templates"
@@ -108,9 +84,8 @@
   [showPaginator]="false"
   [pageOnFront]="false"
   [rowStriped]="false"
-  [showToolbar]="true"
+  [showToolbar]="false"
   [showColumnMenuButton]="false"
-  [toolbarTemplate]="toolbarTpl"
   [sortActive]="selectEformsSort$ | async"
   [sortDirection]="selectEformsIsSortDsc$ | async"
   (sortChange)="sortTable($event)">
@@ -132,7 +107,7 @@
   <div [innerHTML]="row.description"></div>
 </ng-template>
 <ng-template #tagsTpl let-row let-i="index">
-  <div class="">
+  <div>
     <div>
       <a
         mat-icon-button
@@ -154,7 +129,7 @@
   </div>
 </ng-template>
 <ng-template #pairingUpdateTpl let-row let-i="index">
-  <div class="">
+  <div>
     <div>
       <button
         *ngIf="row.deployedSites.length > 0 &&
@@ -187,26 +162,17 @@
                     'Click to pair eForm with user(s)' | translate
                   }}"
       >
-        <!--                {{ 'Pair eForm' | translate }}-->
         <mat-icon>link</mat-icon>
       </button>
-      <!-- <ng-container *ngIf="checkEformPermissions(templateDto.id, userClaimsEnum.eFormsPairingRead)">
-        <p class="paragraph-sm" id="eform-paired-username" *ngFor="let deployedSite of templateDto.deployedSites">
-          {{deployedSite.siteName}}
-        </p>
-      </ng-container>-->
     </div>
   </div>
 </ng-template>
 <ng-template #actionsTpl let-row let-i="index">
-  <div class="">
-
+  <div>
     <button id="actionMenu" mat-icon-button [matMenuTriggerFor]="menu">
       <mat-icon>more_vert</mat-icon>
     </button>
     <mat-menu #menu="matMenu">
-
-
       <button
         mat-menu-item
         *ngIf="row.hasCases &&
@@ -347,16 +313,9 @@
         <mat-icon svgIcon="file-upload"></mat-icon>
         <span>{{ 'Upload ZIP archive' | translate }}</span>
       </button>
-      <!--<button mdbBtn class="btn-accent text-black-50 btn-icon mb-2" id="eform-report-button"
-              *ngIf="checkEformPermissions(templateDto.id, userClaimsEnum.eformsReadJasperReport)"
-              [routerLink]="['./report', templateDto.id]"
-              matTooltip="{{ 'Jasper Report' | translate }}">
-        <fa-icon icon="receipt" [fixedWidth]="true" size="lg"></fa-icon>
-      </button>-->
     </mat-menu>
   </div>
 </ng-template>
-<!--pagination(if required)-->
 <app-eforms-tags
   #modalTags
   [availableTags]="availableTags"

--- a/eform-client/src/app/modules/eforms/components/eforms-page/eforms-page.component.ts
+++ b/eform-client/src/app/modules/eforms/components/eforms-page/eforms-page.component.ts
@@ -40,6 +40,8 @@ import {
   selectEformAllowManagingEformTags
 } from 'src/app/state/auth/auth.selector';
 import {Store} from '@ngrx/store';
+import {Router} from '@angular/router';
+import {AppMenuStateService} from 'src/app/common/store';
 import {
   selectEformsIsSortDsc,
   selectEformsNameFilter,
@@ -63,6 +65,13 @@ export class EformsPageComponent implements OnInit, OnDestroy {
   dialog = inject(MatDialog);
   private overlay = inject(Overlay);
   private translateService = inject(TranslateService);
+  private router = inject(Router);
+  private appMenuStateService = inject(AppMenuStateService);
+
+  // Resolved once in ngOnInit — getTitleByUrl subscribes to the menu store
+  // internally without unsubscribing, so calling it from the template would
+  // leak one subscription per change-detection tick.
+  public pageTitle: string = '';
 
   @ViewChild('modalTags', {static: true}) modalTags: EformsTagsComponent;
 
@@ -88,6 +97,7 @@ export class EformsPageComponent implements OnInit, OnDestroy {
   eformColumnsModalComponentAfterClosedSub$: Subscription;
   eformEditParingModalComponentAfterClosedSub$: Subscription;
   eformRemoveEformModalComponentAfterClosedSub$: Subscription;
+  titleSub$: Subscription;
   private selectCurrentUserClaims$ = this.store.select(selectCurrentUserClaims);
   public selectEformAllowManagingEformTags$ = this.store.select(selectEformAllowManagingEformTags)
   public selectCurrentUserClaimsEformsCreate$ = this.store.select(selectCurrentUserClaimsEformsCreate);
@@ -137,6 +147,12 @@ export class EformsPageComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    // Resolve the page title once menus hydrate; recompute when they emit.
+    // getTitleByUrl reads from the menu store internally — we drive it from
+    // the menu emission instead of calling it per template change-detection.
+    this.titleSub$ = this.appMenuStateService.leftAppMenus$.subscribe(() => {
+      this.pageTitle = this.appMenuStateService.getTitleByUrl(this.router.url);
+    });
     this.loadEformsPermissions();
   }
 
@@ -154,19 +170,13 @@ export class EformsPageComponent implements OnInit, OnDestroy {
 
   loadAllTags() {
     // load tags after call load templates (not know why)
-    //if (this.userClaims.eformsReadTags) {
-      //debugger;
-      this.getAvailableTagsSub$ = this.eFormTagService.getAvailableTags()
-        .subscribe((data) => {
-          if (data && data.success) {
-            this.availableTags = data.model;
-            this.loadSelectedUserTags();
-          }
-        });
-    // } else {
-    //   debugger;
-    //   this.loadAllTemplates();
-    // }
+    this.getAvailableTagsSub$ = this.eFormTagService.getAvailableTags()
+      .subscribe((data) => {
+        if (data && data.success) {
+          this.availableTags = data.model;
+          this.loadSelectedUserTags();
+        }
+      });
   }
 
   saveTag(e: CommonDictionaryModel) {


### PR DESCRIPTION
## Summary
- Replaces the root-page `<eform-new-subheader>` plus the standalone `<ng-template #toolbarTpl>` Tags dropdown with a single `mat-card.eform-sub-header` containing the page title, Search, Tags dropdown, Import / Manage tags / New from XML / New eForm buttons in one right-aligned wrapping flex row.
- Page title now resolves via `appMenuStateService.leftAppMenus$` (mirroring the property-workers pattern).
- The mtx-grid is no longer asked to render an empty toolbar (`[showToolbar]="false"`, no `[toolbarTemplate]`).

## Test plan
- [ ] Load `/` — title "Mine eForms" left-aligned at top of card; Search + Tags + Import + Manage tags + New from XML + New eForm right-aligned in one row.
- [ ] Open the Tags dropdown — selecting/deselecting a tag still filters the grid (saveTag/removeSavedTag fire as before).
- [ ] Permission gates: as a non-admin without `eformsCreate` claim, Import / XML / New eForm buttons should hide.
- [ ] Search input still debounces and refreshes the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)