### PR TITLE
fix(account-management): make UserSetPasswordComponent standalone

### DIFF
--- a/eform-client/src/app/modules/account-management/account-management.module.ts
+++ b/eform-client/src/app/modules/account-management/account-management.module.ts
@@ -7,7 +7,7 @@ import {
   UserModalComponent,
   ProfileSettingsComponent,
   RemoveUserModalComponent,
-  UsersPageComponent, UserSetPasswordComponent,
+  UsersPageComponent,
 } from './components';
 import {AccountManagementRouting} from './account-management.routing';
 import {TranslateModule} from '@ngx-translate/core';
@@ -51,14 +51,13 @@ import {MatMenu, MatMenuItem, MatMenuTrigger} from '@angular/material/menu';
         MatMenuItem,
         MatMenuTrigger,
     ],
-  declarations: [
-    ChangePasswordComponent,
-    ProfileSettingsComponent,
-    UsersPageComponent,
-    UserModalComponent,
-    RemoveUserModalComponent,
-    UserSetPasswordComponent,
-  ],
+    declarations: [
+        ChangePasswordComponent,
+        ProfileSettingsComponent,
+        UsersPageComponent,
+        UserModalComponent,
+        RemoveUserModalComponent,
+    ],
 })
 export class AccountManagementModule {
 }

--- a/eform-client/src/app/modules/account-management/components/users/user-set-password-modal/user-set-password.component.ts
+++ b/eform-client/src/app/modules/account-management/components/users/user-set-password-modal/user-set-password.component.ts
@@ -1,14 +1,30 @@
 import {Component, EventEmitter, OnInit, inject} from '@angular/core';
-import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {CommonModule} from '@angular/common';
+import {MAT_DIALOG_DATA, MatDialogModule, MatDialogRef} from '@angular/material/dialog';
 import {UserInfoModel} from 'src/app/common/models';
-import {FormBuilder, FormGroup, Validators, AbstractControl} from '@angular/forms';
+import {FormBuilder, FormGroup, Validators, AbstractControl, ReactiveFormsModule} from '@angular/forms';
 import {AuthService} from 'src/app/common/services';
 import {ChangePasswordAdminModel} from 'src/app/common/models/user/change-password-admin.model';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatIconModule} from '@angular/material/icon';
+import {MatPasswordStrengthModule} from '@angular-material-extensions/password-strength';
+import {TranslateModule} from '@ngx-translate/core';
 
 @Component({
   selector: 'app-user-set-password',
   templateUrl: './user-set-password.component.html',
-  standalone: false
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatPasswordStrengthModule,
+    TranslateModule,
+  ],
 })
 export class UserSetPasswordComponent implements OnInit {
   private authService = inject(AuthService);


### PR DESCRIPTION
## Summary

- Convert `UserSetPasswordComponent` to a **standalone** Angular component with its own `imports: [...]` (CommonModule, ReactiveFormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatIconModule, MatPasswordStrengthModule, TranslateModule).
- Remove it from `AccountManagementModule.declarations[]` and from the barrel destructure.

## Why

Opening the set-password dialog from a route outside `AccountManagementModule` — e.g. the backend-configuration-pn property-workers page at `/plugins/backend-configuration-pn/property-workers` — produced a runtime error:

```
NG0302: The pipe 'translate' could not be found in the '_UserSetPasswordComponent' component.
```

Root cause: `AccountManagementModule` is **lazy-loaded** (`app.routing.ts:61`). When the dialog is invoked via `MatDialog.open(UserSetPasswordComponent, ...)` from another lazy chunk before AccountManagement has ever been navigated to, the declaring NgModule's pipe/directive scope (including `TranslateModule`) is not in the runtime registry yet. The dialog class is reachable (it was tree-imported), but its template compilation context is not.

Making the component standalone gives it a self-contained directive/pipe scope, independent of any NgModule load order. Same fix applies cleanly because the dialog is only ever opened via `MatDialog.open(...)` — its selector is never used in any template.

## Test plan

- [ ] `/plugins/backend-configuration-pn/property-workers` → open "Set password" on a property worker → dialog renders with translated labels, no NG0302 in console.
- [ ] `/account-management/users` → "Set password" on a user → no regression.
- [ ] CI green (build + lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)