### PR TITLE
fix(shared-tags): refresh tag list in-place after create/edit/delete

### DIFF
--- a/eform-client/src/app/common/modules/eform-shared-tags/components/eforms-tags/eforms-tags.component.ts
+++ b/eform-client/src/app/common/modules/eform-shared-tags/components/eforms-tags/eforms-tags.component.ts
@@ -103,7 +103,7 @@ export class EformsTagsComponent implements OnDestroy, OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (!changes.availableTags.firstChange && changes.availableTags && this.dialogRef) {
-      this.dialogRef.componentInstance.availableTags = changes.availableTags.currentValue;
+      this.dialogRef.componentInstance.setAvailableTags(changes.availableTags.currentValue);
     }
   }
 }

--- a/eform-client/src/app/common/modules/eform-shared-tags/components/shared-tags/shared-tags.component.html
+++ b/eform-client/src/app/common/modules/eform-shared-tags/components/shared-tags/shared-tags.component.html
@@ -9,7 +9,8 @@
     [rowStriped]="false"
     [showPaginator]="false"
     [showToolbar]="false"
-    [pageSize]="availableTags.length"
+    <!-- mtx-grid caches pageSize on init; use a large constant so refreshed [data] is never clipped. paginator is hidden. -->
+    [pageSize]="1000"
   >
   </mtx-grid>
 

--- a/eform-client/src/app/common/modules/eform-shared-tags/components/shared-tags/shared-tags.component.html
+++ b/eform-client/src/app/common/modules/eform-shared-tags/components/shared-tags/shared-tags.component.html
@@ -2,6 +2,7 @@
 
 <div mat-dialog-content style="min-width: 420px; overflow-x: hidden">
 
+  <!-- pageSize: mtx-grid caches the initial value, so a constant larger than any realistic row count is the simplest way to keep refreshed [data] from being clipped. Paginator is hidden. -->
   <mtx-grid
     [data]="availableTags"
     [columns]="tableHeaders"
@@ -9,7 +10,6 @@
     [rowStriped]="false"
     [showPaginator]="false"
     [showToolbar]="false"
-    <!-- mtx-grid caches pageSize on init; use a large constant so refreshed [data] is never clipped. paginator is hidden. -->
     [pageSize]="1000"
   >
   </mtx-grid>

--- a/eform-client/src/app/common/modules/eform-shared-tags/components/shared-tags/shared-tags.component.ts
+++ b/eform-client/src/app/common/modules/eform-shared-tags/components/shared-tags/shared-tags.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, OnInit, inject} from '@angular/core';
+import {ChangeDetectorRef, Component, EventEmitter, OnInit, inject} from '@angular/core';
 import {
   CommonDictionaryModel,
   SharedTagModel,
@@ -14,6 +14,7 @@ import {MtxGridColumn} from '@ng-matero/extensions/grid';
 })
 export class SharedTagsComponent implements OnInit {
   dialogRef = inject<MatDialogRef<SharedTagsComponent>>(MatDialogRef);
+  private cdr = inject(ChangeDetectorRef);
 
   public availableTags: SharedTagModel[] = [];
   public showMultipleCreateBtn: boolean = false;
@@ -63,5 +64,10 @@ export class SharedTagsComponent implements OnInit {
 
   showMultipleCreateTagModal() {
     this.showMultipleCreateTag.emit();
+  }
+
+  setAvailableTags(tags: SharedTagModel[]): void {
+    this.availableTags = [...tags];
+    this.cdr.detectChanges();
   }
 }

--- a/eform-client/src/app/modules/email-recipients/components/tags/email-recipients-tags.component.ts
+++ b/eform-client/src/app/modules/email-recipients/components/tags/email-recipients-tags.component.ts
@@ -102,7 +102,7 @@ export class EmailRecipientsTagsComponent implements OnChanges, OnDestroy {
 
   ngOnChanges(changes: SimpleChanges): void {
     if(!changes.availableTags.firstChange && changes.availableTags && this.dialogRef){
-      this.dialogRef.componentInstance.availableTags = changes.availableTags.currentValue;
+      this.dialogRef.componentInstance.setAvailableTags(changes.availableTags.currentValue);
     }
   }
 }


### PR DESCRIPTION
## Summary

Tag-management dialog (`SharedTagsComponent`) appeared frozen on its initial data — creating/editing/deleting a tag did not show in the open list. User had to close and reopen the dialog to see the result.

## Root cause

Confirmed by runtime diagnostics. Two interacting issues:

1. **Cross-component imperative mutation:** wrappers updated the open dialog via `this.dialogRef.componentInstance.availableTags = newValue`. The new reference landed on the field, but because `availableTags` is not an `@Input` on `SharedTagsComponent`, Angular's input-diff machinery never fired and the dialog view's change-detection pass after the mutation was timing-dependent.
2. **`mtx-grid` caches `[pageSize]` on init.** The template had `[pageSize]="availableTags.length"` — works on first render, ignored on later updates. Combined with `[showPaginator]="false"`, newly added rows were silently clipped even when fresh `[data]` arrived.

## Changes

- `shared-tags.component.ts` — inject `ChangeDetectorRef`; add public `setAvailableTags(tags)` that clones the array and calls `cdr.detectChanges()` on the dialog view
- `shared-tags.component.html` — `[pageSize]="availableTags.length"` → `[pageSize]="1000"` with an inline comment explaining the `mtx-grid` cache. Tag counts never approach this.
- `eforms-tags.component.ts`, `email-recipients-tags.component.ts` — `ngOnChanges` routes through `setAvailableTags()` instead of imperative assignment

Verified at runtime: the chain (`tagsChanged.emit()` → parent `loadAllTags()` → `ngOnChanges` → `setAvailableTags(10 tags)` → `cdr.detectChanges()` → grid renders 10 rows) now visibly refreshes the list without closing.

## Plugin wrappers — follow-up PRs

`PlanningTagsComponent` (items-planning) and `FileTagsComponent` (backend-configuration) have the same pattern and need the same swap to `setAvailableTags()`. They live in separate plugin repos; PRs will follow once their plugin repos are at a clean checkpoint for `devgetchanges.sh`.

## Test plan

- [ ] `/` → "Manage tags" → "+ Add new" → submit. New tag appears in the list without closing.
- [ ] Same dialog: edit a tag → renamed in place.
- [ ] Same dialog: delete a tag → removed from list.
- [ ] Email recipients tag manager (same flow).
- [ ] No regression on dialog open with existing tags rendered correctly.
- [ ] CI green (build + tests + playwright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)