### PR TITLE
style(shared-tags): horizontal action icons in tag-management dialog

### DIFF
--- a/eform-client/src/app/common/modules/eform-shared-tags/components/shared-tags/shared-tags.component.html
+++ b/eform-client/src/app/common/modules/eform-shared-tags/components/shared-tags/shared-tags.component.html
@@ -44,7 +44,7 @@
 </ng-template>
 
 <ng-template #actionsTpl let-row>
-  <div>
+  <div class="table-actions">
     <button
       *ngIf="!row.isLocked"
       mat-icon-button


### PR DESCRIPTION
## Summary

Apply the existing `.table-actions` class to the action-cell wrapper `<div>` in the tag-management dialog so the edit/delete icons render side-by-side instead of stacking vertically.

## Why

The colocated SCSS at `shared-tags.component.scss:33-36` already defines:
```scss
.table-actions {
  display: flex;
  gap: 4px;
}
```

…but the template's wrapper `<div>` had no class, so the two `mat-icon-button`s laid out as block-level siblings and wrapped onto two rows. Adding the class gives the rule something to bind to.

## Visual delta

| Before | After |
|---|---|
| Pencil icon over trash icon (vertical) | Pencil and trash side-by-side (horizontal) |

This is the first DM alignment fix for the `SharedTagsComponent` dialog. Inherited by all four call sites (eForms page, email recipients, items-planning plugin, backend-configuration files plugin).

## Test plan

- [ ] `/` → "Manage tags" → each row shows edit + delete icons horizontally.
- [ ] Hover/click still works on both icons.
- [ ] No regression in other dialogs that use `SharedTagsComponent`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)