### PR TITLE
style(shared-tags): align Add new/bulk buttons with DM filled/stroked hierarchy

### DIFF
--- a/eform-client/src/app/common/modules/eform-shared-tags/components/shared-tags/shared-tags.component.html
+++ b/eform-client/src/app/common/modules/eform-shared-tags/components/shared-tags/shared-tags.component.html
@@ -18,7 +18,7 @@
   <div class="d-flex flex-row justify-content-start align-items-center gap-12 py-2">
     <button
       *ngIf="showMultipleCreateBtn"
-      mat-button
+      mat-stroked-button
       color="primary"
       id="newTagsBtn"
       (click)="showMultipleCreateTagModal()"
@@ -27,7 +27,7 @@
       <span>{{ 'Add bulk' | translate }}</span>
     </button>
     <button
-      mat-button
+      mat-flat-button
       color="primary"
       id="newTagBtn"
       (click)="showCreateTagModal()"


### PR DESCRIPTION
## Summary

Two-token directive swap in the tag-management dialog to bring it in line with the Design Manual's button hierarchy.

| Button | Before | After | DM token |
|---|---|---|---|
| "Add new" (primary CTA) | \`mat-button\` (transparent, teal pill) | \`mat-flat-button\` (filled, blue, 4px radius) | \`btn-filled\` |
| "Add bulk" (secondary, plugin-only) | \`mat-button\` (transparent, teal pill) | \`mat-stroked-button\` (outlined) | secondary |

The workspace theme already maps \`.mat-mdc-unelevated-button\` → \`--md-primary\` / \`--md-on-primary\` / 4px and \`.mat-mdc-outlined-button\` to the matching outlined tokens, so no SCSS changes were needed — pure template change.

## Why

The previous \`mat-button\` directive renders Angular Material's text-only style, which the legacy theme had given a 9999px pill radius and the eform theme's teal primary color (\`rgb(0, 106, 106)\`). The DM dialog spec uses \`btn-filled\` for the primary CTA (\`background: var(--md-primary)\`, white text, 4px radius). After this change, \`getComputedStyle\` returns:

- \`background: rgb(11, 87, 208)\` = \`#0b57d0\` (DM \`--md-primary\`) ✓
- \`color: rgb(255, 255, 255)\` ✓
- \`border-radius: 4px\` ✓

"Add bulk" is conditionally rendered (\`*ngIf="showMultipleCreateBtn"\`) and only appears in the items-planning and backend-configuration plugin contexts. Splitting it to \`mat-stroked-button\` preserves a clear primary/secondary hierarchy when both buttons render side-by-side.

## Test plan

- [ ] \`/\` → "Manage tags" → "Add new" renders filled blue, 4px radius.
- [ ] Items-planning tag manager → both buttons visible: "Add new" filled, "Add bulk" outlined.
- [ ] No regression in \`SharedTagsComponent\` consumers (email recipients, file tags).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)