### PR TITLE
style(workspace): center toggle in eform-sub-header toolbar row

### DIFF
--- a/eform-client/src/scss/components/_workspace-mat-overrides.scss
+++ b/eform-client/src/scss/components/_workspace-mat-overrides.scss
@@ -798,6 +798,18 @@ body.theme-workspace {
     }
   }
 
+  // Slide toggles inside an .eform-sub-header toolbar are 24px tall sitting
+  // in a row with align-items: end against 40px form-field pills / buttons.
+  // Default bottom-alignment leaves the toggle midpoint 8px BELOW the field
+  // midline. Lift it by (40 − 24) / 2 = 8px so its midpoint matches the
+  // visible pill midline. Also cancel the .mt-2 utility some templates
+  // apply to the toggle, which would otherwise nudge it down within its
+  // own flex item box.
+  .eform-sub-header mat-slide-toggle {
+    margin-top: 0 !important;
+    margin-bottom: 8px;
+  }
+
   // =========================================================================
   // Progress spinner (mat-mdc-progress-spinner) — force workspace primary blue
   // Material 18+ M3 ships the spinner with the accent palette (cyan) by


### PR DESCRIPTION
## Summary

Lift mat-slide-toggle by 8px in the workspace theme's \`.eform-sub-header\` so its midpoint aligns with the 40px field/button midline, matching the equivalent classic-theme fix landed in #7909.

## Before / after on \`/plugins/backend-configuration-pn/property-workers\` (workspace theme)

| | field mid | toggle mid | diff |
|---|---|---|---|
| Before | 203 | 211 | **+8px (toggle below center)** |
| After  | 203 | 203 | **0** |

## Why the fix differs from classic

Classic could collapse the row by dropping a dead \`mt-4\` margin from \`.text-field--rounded\` wrappers. Workspace has no \`.text-field--rounded\` — its dead space comes from the form-field's intrinsic 22px \`padding-top\` (label-space reserve), which can't be removed without breaking the stacked label spec.

So in workspace, the row stays 85px tall and we lift the toggle directly: \`margin-bottom: 8px\` ((40 − 24) / 2) shifts the bottom-aligned toggle up to the field midline. Plus \`margin-top: 0\` cancels the \`.mt-2\` utility some templates apply.

## Test plan

- [ ] \`/plugins/backend-configuration-pn/property-workers\` on workspace theme: "Vis fratrådte" toggle visually centered with the search/tag/location pills + buttons.
- [ ] Same page on classic theme: no regression (#7909 fix still in effect).
- [ ] Other workspace pages with toolbar toggles (calendar header, planning filters) render with toggles centered.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)