### PR TITLE
fix(dev): proxy /hub/** with ws:true to API for SignalR

### DIFF
--- a/eform-client/proxy.config.json
+++ b/eform-client/proxy.config.json
@@ -5,6 +5,13 @@
     "logLevel": "debug",
     "proxyTimeout": 3600000
   },
+  "/hub/**":{
+    "target": "http://0.0.0.0:5000",
+    "secure": false,
+    "ws": true,
+    "logLevel": "debug",
+    "proxyTimeout": 3600000
+  },
   "/output/**":{
     "target": "http://0.0.0.0:5000",
     "secure": false,


### PR DESCRIPTION
## Summary

Adds a `/hub/**` route to the Angular dev proxy so SignalR connections from `ng serve` actually reach the API. The proxy previously only forwarded `/api/**` and `/output/**`, so any plugin that mounted a hub at `/hub/<name>` (e.g., the kanban plugin's `KanbanHub` at `/hub/kanban`) had its negotiate request 404 against the dev server. The client-side `HubConnectionBuilder().start()` then rejected, was caught and logged as a warning, and any real-time feature degraded to "never fires" in dev — silently.

This was the latent half of the kanban drag-and-drop regression (the matching server-side fix lands in [eform-kanban-plugin#1](https://github.com/microting/eform-kanban-plugin/pull/1)).

`ws: true` is essential — without it the WebSocket upgrade is not proxied even if negotiate succeeds.

Production unaffected: the frontend and API are served from the same origin in built deployments and never hit this dev proxy.

## Test plan

- [x] `curl -s -o /dev/null -w '%{http_code}' http://localhost:4200/hub/kanban/negotiate?negotiateVersion=1 -X POST` returns 200 after `ng serve` restart (was 404)
- [x] Playwright drag-and-drop spec passes against the dev stack (verifies SignalR end-to-end)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)