### PR TITLE
test(translation): FAKE_TRANSLATE_E2E sentinel key for e2e fake translations

### DIFF
--- a/eFormAPI/eFormAPI.Web/Services/TranslationService.cs
+++ b/eFormAPI/eFormAPI.Web/Services/TranslationService.cs
@@ -17,6 +17,14 @@ public class TranslationService : ITranslationService
     public async Task<OperationDataResult<string>> TranslateText(string sourceText, string sourceLanguageCode,
         string targetLanguageCode, string apiKey)
     {
+        // E2E hook: a sentinel key returns deterministic fake text instead of
+        // calling Google, so the translate flow is testable without a real key.
+        // Never matches a real Google API key.
+        if (apiKey == "FAKE_TRANSLATE_E2E")
+        {
+            return new OperationDataResult<string>(true, "", $"[{targetLanguageCode}] {sourceText}");
+        }
+
         //string apiKey = "YOUR_API_KEY";
         string apiUrl = "https://translation.googleapis.com/language/translate/v2?key=" + apiKey;
 


### PR DESCRIPTION
Adds a tiny e2e hook to `TranslationService.TranslateText`: when the configured Google API key is the sentinel **`FAKE_TRANSLATE_E2E`**, it returns deterministic fake text `"[<targetLang>] <sourceText>"` instead of calling Google.

This lets the backend-configuration calendar **translate** feature be exercised end-to-end (Playwright) without a real Google key — the e2e backend is started with `/api-key=FAKE_TRANSLATE_E2E`, so `api/translation-possible` reports available (already true for any non-empty key) and `api/get-translation` returns the faked string.

The sentinel can never match a real Google API key, and production never sets it. No behavior change for real keys.

Prerequisite for the plugin-side e2e spec (eform-backendconfiguration-plugin), whose CI builds the backend image from this repo's `stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)