### PR TITLE
fix(workspace-theme): remove tinted backgrounds from menu and header areas

### DIFF
--- a/eform-client/src/scss/components/_workspace-patterns.scss
+++ b/eform-client/src/scss/components/_workspace-patterns.scss
@@ -89,6 +89,16 @@ body.theme-workspace {
     flex: 1 1 auto;
   }
 
+  // Legacy filter / sub-header band. styles.scss paints `.eform-sub-header`
+  // with `var(--bg)` (#f8fafd) via an unscoped !important rule, so the filter
+  // toolbar stays tinted under the workspace theme even after the surface
+  // tokens went white. Pin it to the page surface so it matches the content
+  // area in both modes (white in light, #131314 in dark). !important + the
+  // theme-scoped specificity beats the global rule.
+  .eform-sub-header {
+    background: var(--md-surface) !important;
+  }
+
   // ---------------------------------------------------------------------------
   // 2. Navigation drawer (base — no icon rail variant)
   // ---------------------------------------------------------------------------

--- a/eform-client/src/scss/components/_workspace-patterns.scss
+++ b/eform-client/src/scss/components/_workspace-patterns.scss
@@ -33,11 +33,7 @@ body.theme-workspace {
     align-items: center;
     justify-content: space-between;
     padding: var(--spacing-md) var(--spacing-2xl);
-    background: color-mix(
-      in srgb,
-      var(--md-primary) 10%,
-      var(--md-surface-container)
-    );
+    background: var(--md-surface-container);
     color: var(--md-on-surface);
     border-bottom: 1px solid var(--md-surface-variant);
     box-shadow: none;
@@ -70,11 +66,7 @@ body.theme-workspace {
 
   // Existing app-header element (eform-client/src/app/components/header)
   app-header > header {
-    background: color-mix(
-      in srgb,
-      var(--md-primary) 10%,
-      var(--md-surface-container)
-    );
+    background: var(--md-surface-container);
     color: var(--md-on-surface);
     border-bottom: 1px solid var(--md-surface-variant);
     padding: var(--spacing-sm) var(--spacing-2xl);
@@ -735,6 +727,18 @@ body.theme-workspace {
   // app/components/navigation/navigation.component.scss use --rounded-full
   // (9999px = pill) — the design spec wants 8px rounded rectangles. Override
   // here so the workspace variant gets the design's nav item shape.
+
+  // The <mat-tree> element inherits Angular Material's M3 default surface
+  // (#f7faf9 light) via --mat-tree-container-background-color, painting the
+  // whole menu a faint tint distinct from the white drawer beneath it. Pin it
+  // to the drawer surface so the menu reads as one clean surface in both modes.
+  // Scoped to mat-drawer so folder-picker / tree-select trees are untouched.
+  // The token is what Angular Material reads for the tree container fill; the
+  // raw `background` covers the host wrapper, which doesn't route through it.
+  mat-drawer mat-tree {
+    --mat-tree-container-background-color: var(--md-surface-container);
+    background: var(--md-surface-container);
+  }
 
   mat-tree .nav-link {
     border-radius: var(--radius-lg, 8px) !important;

--- a/eform-client/src/scss/components/_workspace-patterns.scss
+++ b/eform-client/src/scss/components/_workspace-patterns.scss
@@ -99,6 +99,28 @@ body.theme-workspace {
     background: var(--md-surface) !important;
   }
 
+  // The calendar plugin's own toolbar (.calendar-header) paints its bar with
+  // the legacy var(--bg) (#f8fafd) and its property pills with var(--bg-soft)
+  // — a token the workspace theme never defines, so the pills fall back to a
+  // hardcoded grey that also breaks in dark mode. Re-point both at the
+  // workspace surface tokens so the calendar filter bar matches the rest of
+  // the de-tinted chrome and tracks light/dark correctly.
+  .calendar-header {
+    background: var(--md-surface) !important;
+
+    // !important: the plugin's encapsulated `.calendar-header .property-pill`
+    // rule (specificity 0,4,0 with two [_ngcontent] attrs) out-specifies this
+    // theme override otherwise, and its hardcoded #f1f3f4 fallback stays light
+    // grey in dark mode.
+    .property-pill {
+      background: var(--md-surface-variant) !important;
+
+      &:hover {
+        background: color-mix(in srgb, var(--md-on-surface) 8%, var(--md-surface-variant)) !important;
+      }
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // 2. Navigation drawer (base — no icon rail variant)
   // ---------------------------------------------------------------------------
@@ -745,8 +767,14 @@ body.theme-workspace {
   // Scoped to mat-drawer so folder-picker / tree-select trees are untouched.
   // The token is what Angular Material reads for the tree container fill; the
   // raw `background` covers the host wrapper, which doesn't route through it.
+  // The expandable parent rows (Opgaver, Timeregistrering, …) render as
+  // <mat-expansion-panel>, which carries its OWN M3 surface token
+  // (--mat-expansion-container-background-color, also #f7faf9). Setting it
+  // here lets the inherited custom property flow down to those panels so they
+  // match the rest of the menu instead of keeping the tint.
   mat-drawer mat-tree {
     --mat-tree-container-background-color: var(--md-surface-container);
+    --mat-expansion-container-background-color: var(--md-surface-container);
     background: var(--md-surface-container);
   }
 

--- a/eform-client/src/scss/themes/_workspace.scss
+++ b/eform-client/src/scss/themes/_workspace.scss
@@ -73,7 +73,7 @@ $workspace-tokens: (
       md-on-primary: #ffffff,
       md-primary-container: #d3e3fd,
       md-secondary-container: #dfe2eb,
-      md-surface: #f8fafd,
+      md-surface: #ffffff,
       md-surface-container: #ffffff,
       md-surface-variant: #e1e7ef,
       md-on-surface: #1f1f1f,
@@ -175,7 +175,7 @@ $workspace-tokens: (
       text-child-muted: #5f6368,
       text-error-message: #b3261e,
 
-      surface-subheader: #e1e7ef,
+      surface-subheader: #ffffff,
       surface-error-message: #fde8e7,
 
       spinner-overlay-bg: #{rgba(0, 0, 0, 0.3)},
@@ -324,7 +324,7 @@ $workspace-tokens: (
       text-child-muted: #c4c7c5,
       text-error-message: #f2b8b5,
 
-      surface-subheader: #444746,
+      surface-subheader: #131314,
       surface-error-message: #{rgba(178, 38, 30, 0.2)},
 
       spinner-overlay-bg: #{rgba(0, 0, 0, 0.5)},


### PR DESCRIPTION
## Summary

Removes the blue-grey / greenish tinted backgrounds from the **workspace theme**'s navigation menu, secondary panel, page background, top app bar, and filter toolbars — pure white in light mode, flat neutral in dark mode. Everything is scoped to `body.theme-workspace`; the legacy `theme-eform` is untouched.

Design spec: `docs/superpowers/specs/2026-06-10-workspace-detint-design.md` (workspace root repo).

## Root cause

Two sources the workspace theme never reconciled:
1. **Angular Material M3 default surface** (`#f7faf9`) left on component tokens — `--mat-tree-container-background-color` (nav tree) and `--mat-expansion-container-background-color` (expandable parent items).
2. **Legacy tokens** `var(--bg)` (`#f8fafd`) / `var(--bg-soft)` (undefined in workspace → hardcoded grey, broken in dark) used by `.eform-sub-header` and the calendar plugin's `.calendar-header`.

All re-pointed at the workspace surface tokens (`--md-surface`, `--md-surface-container`, `--md-surface-variant`).

## Changes (2 files, scoped to `body.theme-workspace`)

- `scss/themes/_workspace.scss` — light `md-surface` `#f8fafd`→`#ffffff`; light `surface-subheader` `#e1e7ef`→`#ffffff`; dark `surface-subheader` `#444746`→`#131314`.
- `scss/components/_workspace-patterns.scss` — top app bar loses its `color-mix(primary 10%)` tint → `var(--md-surface-container)`; nav `mat-tree` (+ inherited expansion panels) pinned to the drawer surface; `.eform-sub-header` and `.calendar-header` (bar + pills) re-pointed to surface tokens.

## Regions de-tinted

Main menu · expandable parent items · secondary "Mine ejendomme / Mine tavler" panel · page background · top app bar · `.eform-sub-header` filter toolbar · calendar `.calendar-header` toolbar + property pills.

## Preserved (unchanged)

Active/selected nav highlight (`#d3e3fd`), hover, row hover, status pills/chips, calendar week badge, sidebar shadow, top-bar divider, table borders.

## Verification

Verified live (light + dark) via `getComputedStyle` on the calendar and property-workers pages: every region resolves to the target surface; all interaction states preserved. Reviewed by code-reviewer + code-simplifier subagents (no issues).

## Out of scope

Kanban board columns, gantt headers, time-planning table header/summary tints — content internals, not menu/header chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)