### PR TITLE
fix(grid): make left-pinned column opaque so scrolled content can't show through

### DIFF
--- a/eform-client/src/scss/styles.scss
+++ b/eform-client/src/scss/styles.scss
@@ -1402,6 +1402,10 @@ body.theme-eform {
 
 body.theme-eform {
   .mtx-grid .mat-table-sticky-left {
+    // Opaque background so horizontally-scrolled cell content cannot show through the
+    // pinned first column (the CDK positions it sticky but never paints a background).
+    // Mirrors the right-pinned column rule (.mat-table-sticky-right) below.
+    background: var(--bg, #FFF) !important;
     border-right: 1px solid var(--border, #EBEFF2) !important;
   }
 


### PR DESCRIPTION
## The bug
In the timeplanning planning view (`/plugins/time-planning-pn/planning`), scrolling the table horizontally showed the day-column content (coloured day cells, "(id: …)") **through** the pinned first "Navn" column.

## Root cause
The first column is pinned via mtx-grid `pinned: 'left'`. The CDK renders it `position: sticky` with a correct (elevated) z-index, but **never paints a background** — that's the app's job. The pinned cells had no background, while the scrolling day cells have opaque colours (`green/red/grey/white-background !important`), so they bled through. The **right**-pinned column was already fine because the app gives it `background: var(--bg, #FFF) !important`; the left one was just never given the equivalent.

## The fix
Add `background: var(--bg, #FFF) !important;` to the existing `.mtx-grid .mat-table-sticky-left` rule (mirrors the right-pinned rule). Theme-token background, no z-index change. Targets only pinned left columns (the Name column carries no day-cell colour class, so there's no conflict). Benignly also makes the insight-dashboard left-pinned column opaque.

## Verification
Manual: scroll the planning grid horizontally — no day-cell content shows through the "Navn" column (header + body, coloured and plain rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)