### PR TITLE
fix(grid): make left-pinned column opaque on ALL themes (theme-workspace), not just theme-eform

### DIFF
--- a/eform-client/src/scss/styles.scss
+++ b/eform-client/src/scss/styles.scss
@@ -1402,10 +1402,13 @@ body.theme-eform {
 
 // Pinned-left column must be OPAQUE on ALL themes (theme-eform, theme-workspace, dark, …),
 // otherwise the horizontally-scrolled cell content shows through the sticky first column
-// (the CDK positions it sticky but never paints a background). var(--bg) resolves per theme.
+// (the CDK positions it sticky but never paints a background). Use --tp-td-bg — the table cell
+// background (white; same token wired to --mat-table-background-color) — so the pinned column
+// matches the data cells exactly, rather than the tinted page background (--bg is #f8fafd on
+// theme-workspace, which read as a grey tint).
 // NB: the right-pinned rule below is theme-eform-scoped and has the same latent gap on other themes.
 .mtx-grid .mat-table-sticky-left {
-  background: var(--bg, #FFF) !important;
+  background: var(--tp-td-bg, #FFF) !important;
 }
 
 body.theme-eform {

--- a/eform-client/src/scss/styles.scss
+++ b/eform-client/src/scss/styles.scss
@@ -1400,12 +1400,16 @@ body.theme-eform {
   }
 }
 
+// Pinned-left column must be OPAQUE on ALL themes (theme-eform, theme-workspace, dark, …),
+// otherwise the horizontally-scrolled cell content shows through the sticky first column
+// (the CDK positions it sticky but never paints a background). var(--bg) resolves per theme.
+// NB: the right-pinned rule below is theme-eform-scoped and has the same latent gap on other themes.
+.mtx-grid .mat-table-sticky-left {
+  background: var(--bg, #FFF) !important;
+}
+
 body.theme-eform {
   .mtx-grid .mat-table-sticky-left {
-    // Opaque background so horizontally-scrolled cell content cannot show through the
-    // pinned first column (the CDK positions it sticky but never paints a background).
-    // Mirrors the right-pinned column rule (.mat-table-sticky-right) below.
-    background: var(--bg, #FFF) !important;
     border-right: 1px solid var(--border, #EBEFF2) !important;
   }
 


### PR DESCRIPTION
## Follow-up to #7944
#7944 added an opaque background to the mtx-grid left-pinned column, but scoped it under `body.theme-eform`. **Live testing revealed the running instance uses the `theme-workspace` theme** (the `<body>` has `theme-workspace theme-light`, no `theme-eform`), so that rule never matched — the pinned "Navn" column stayed transparent and horizontally-scrolled content still bled through.

## Fix
Move the background to a **theme-agnostic** rule:
```scss
.mtx-grid .mat-table-sticky-left { background: var(--bg, #FFF) !important; }
```
`--bg` is a per-theme token, so the pinned column is opaque **and theme-appropriate** on `theme-eform`, `theme-workspace`, and dark/light. The `theme-eform` rule keeps its `border-right`.

## Verified live
On the running `theme-workspace` instance, the pinned body cells went from `rgba(0,0,0,0)` (transparent) → `rgb(248,250,253)` (= resolved `var(--bg)`), and the bleed-through stopped (confirmed by computed style + screenshot after horizontal scroll).

## Note
The **right**-pinned rule still scopes its background under `body.theme-eform`, so it has the same latent gap on non-eform themes — flagged in a comment for a follow-up if right-pinned bleed-through is reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)