### PR TITLE
fix(translation): real v2 request (ISO codes + URL-encode) + gated sentinel

### DIFF
--- a/eFormAPI/eFormAPI.Web.Tests/TranslationServiceTests.cs
+++ b/eFormAPI/eFormAPI.Web.Tests/TranslationServiceTests.cs
@@ -1,0 +1,26 @@
+using System.Net.Http;
+using NUnit.Framework;
+using eFormAPI.Web.Services;
+
+namespace eFormAPI.Web.Tests;
+
+[TestFixture]
+public class TranslationServiceTests
+{
+    [Test]
+    public void BuildTranslateRequest_NormalisesLocaleToIso_AndEncodesText()
+    {
+        var (url, form) = TranslationService.BuildTranslateRequest("Tank 4", "da", "de-DE", "realkey");
+
+        // Google Translate v2 rejects locale codes — must be bare ISO.
+        Assert.That(form["target"], Is.EqualTo("de"), "de-DE must normalise to de");
+        Assert.That(form["source"], Is.EqualTo("da"));
+        Assert.That(form["q"], Is.EqualTo("Tank 4"));
+        Assert.That(url, Does.Contain("key=realkey"));
+
+        // FormUrlEncodedContent URL-encodes the body — a space becomes '+'.
+        var encoded = new FormUrlEncodedContent(form).ReadAsStringAsync().Result;
+        Assert.That(encoded, Does.Contain("q=Tank+4"));
+        Assert.That(encoded, Does.Contain("target=de"));
+    }
+}

--- a/eFormAPI/eFormAPI.Web/Services/TranslationService.cs
+++ b/eFormAPI/eFormAPI.Web/Services/TranslationService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -18,37 +19,53 @@ public class TranslationService : ITranslationService
         string targetLanguageCode, string apiKey)
     {
         // E2E hook: a sentinel key returns deterministic fake text instead of
-        // calling Google, so the translate flow is testable without a real key.
-        // Never matches a real Google API key.
-        if (apiKey == "FAKE_TRANSLATE_E2E")
+        // calling Google. Gated behind ALLOW_FAKE_TRANSLATE (set only in CI) so
+        // it can NEVER fire in production, even if API_KEY were the sentinel.
+        if (apiKey == "FAKE_TRANSLATE_E2E"
+            && Environment.GetEnvironmentVariable("ALLOW_FAKE_TRANSLATE") == "true")
         {
             return new OperationDataResult<string>(true, "", $"[{targetLanguageCode}] {sourceText}");
         }
 
-        //string apiKey = "YOUR_API_KEY";
-        string apiUrl = "https://translation.googleapis.com/language/translate/v2?key=" + apiKey;
+        var (apiUrl, form) = BuildTranslateRequest(sourceText, sourceLanguageCode, targetLanguageCode, apiKey);
 
         using HttpClient client = new HttpClient();
-        HttpResponseMessage response = await client.PostAsync(apiUrl,
-            new StringContent($"q={sourceText}&source={sourceLanguageCode}&target={targetLanguageCode}",
-                System.Text.Encoding.UTF8, "application/x-www-form-urlencoded"));
+        HttpResponseMessage response = await client.PostAsync(apiUrl, new FormUrlEncodedContent(form));
+        string responseBody = await response.Content.ReadAsStringAsync();
 
         if (response.IsSuccessStatusCode)
         {
-            string responseBody = await response.Content.ReadAsStringAsync();
             var responseObject = JsonSerializer.Deserialize<TranslationResponse>(responseBody);
+            var translated = responseObject?.data?.translations is { Length: > 0 }
+                ? responseObject.data.translations[0].translatedText
+                : null;
+            if (translated != null)
+            {
+                return new OperationDataResult<string>(true, "", translated);
+            }
 
-            Console.WriteLine($"Source: {sourceText}");
-            Console.WriteLine($"Translation: {responseObject.data.translations[0].translatedText}");
-
-
-            return new OperationDataResult<string>(true, "",responseObject.data.translations[0].translatedText);
+            return new OperationDataResult<string>(false, $"Translate: unexpected response: {responseBody}");
         }
-        else
+
+        Console.WriteLine($"Translate error: {response.ReasonPhrase}: {responseBody}");
+        return new OperationDataResult<string>(false, $"Translate failed ({(int)response.StatusCode}): {responseBody}");
+    }
+
+    // Pure + testable: normalise locale codes to bare ISO (de-DE -> de; Google v2
+    // rejects locale codes) and assemble the request. FormUrlEncodedContent will
+    // URL-encode the values (a raw "q=Tank 4" body otherwise 400s).
+    public static (string url, Dictionary<string, string> form) BuildTranslateRequest(
+        string sourceText, string sourceLanguageCode, string targetLanguageCode, string apiKey)
+    {
+        static string Iso(string code) => (code ?? string.Empty).Split('-')[0];
+        var url = "https://translation.googleapis.com/language/translate/v2?key=" + apiKey;
+        var form = new Dictionary<string, string>
         {
-            Console.WriteLine($"Error: {response.ReasonPhrase}");
-        }
-
-        return new OperationDataResult<string>(false, "Error");
+            ["q"] = sourceText ?? string.Empty,
+            ["source"] = Iso(sourceLanguageCode),
+            ["target"] = Iso(targetLanguageCode),
+            ["format"] = "text",
+        };
+        return (url, form);
     }
 }


### PR DESCRIPTION
## What
Makes the real Google Translate v2 call actually work, and hardens the e2e sentinel so it can never fire in production.

## Changes (`eFormAPI.Web`)
- **`TranslationService.cs`**:
  - Extract a pure `BuildTranslateRequest(...)` that **normalises language codes to bare ISO** (`de-DE`→`de`; Google v2 rejects locale codes) and builds the request via **`FormUrlEncodedContent`** (URL-encodes `q` — a raw `q=Tank 4` body previously 400'd).
  - **Surface Google's error body** in the failure message (was generic `"Error"`); null-safe response parse.
  - **Gate the `FAKE_TRANSLATE_E2E` sentinel** behind `Environment.GetEnvironmentVariable("ALLOW_FAKE_TRANSLATE") == "true"` (set only in CI) → can't fire in prod.
- **`TranslationServiceTests.cs`** (NUnit): asserts `de-DE`→`de` and `q=Tank+4` encoding. Passes locally.

## Sequencing
The CI `ALLOW_FAKE_TRANSLATE=true` flag is **already merged** in the plugin (#999) and container (#9) workflows where shard `m` runs, so the calendar-translation e2e keeps passing once this lands. (The frontend repo's own CI doesn't run that shard.)

## Follow-up (not in this PR)
`TranslateText` still constructs `new HttpClient()` per call (pre-existing); could inject `IHttpClientFactory` later. Low impact for this low-volume endpoint.

See spec `2026-06-11-translation-real-apikey-prod-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)