### PR TITLE
Add postNoToast/putNoToast/deleteNoToast to ApiBaseService

### DIFF
--- a/eform-client/src/app/common/services/apiBase.service.ts
+++ b/eform-client/src/app/common/services/apiBase.service.ts
@@ -94,6 +94,13 @@ export class ApiBaseService {
       .pipe(map((response) => this.extractData<T>(response)));
   }
 
+  public postNoToast<T>(method: string, body: any): Observable<any> {
+    const model = JSON.stringify(body);
+    return this.http
+      .post(method, model, {headers: this.setHeaders()})
+      .pipe(map((response) => this.extractDataNoToast<T>(response)));
+  }
+
   public postUrlEncoded<T>(method: string, body: any): Observable<any> {
     return this.http
       .post(method, body.toString(), {
@@ -129,11 +136,27 @@ export class ApiBaseService {
       .pipe(map((response) => this.extractData<T>(response)));
   }
 
+  public deleteNoToast<T>(method: string, params?: any): Observable<any> {
+    return this.http
+      .delete(method, {
+        headers: this.setHeaders(),
+        params: ApiBaseService.setParams(params),
+      })
+      .pipe(map((response) => this.extractDataNoToast<T>(response)));
+  }
+
   public put<T>(method: string, body: any): Observable<any> {
     const model = JSON.stringify(body);
     return this.http
       .put(method, model, {headers: this.setHeaders()})
       .pipe(map((response) => this.extractData<T>(response)));
+  }
+
+  public putNoToast<T>(method: string, body: any): Observable<any> {
+    const model = JSON.stringify(body);
+    return this.http
+      .put(method, model, {headers: this.setHeaders()})
+      .pipe(map((response) => this.extractDataNoToast<T>(response)));
   }
 
   public getBlobData<T>(method: string, params?: any): Observable<any> {


### PR DESCRIPTION
## Summary

Purely additive: `postNoToast`, `putNoToast`, `deleteNoToast` on `ApiBaseService`, exact mirrors of their toasting siblings but routed through the existing `extractDataNoToast` (same as the long-standing `getNoToast`). No existing method or caller changes behavior.

First consumer: the backend-configuration calendar service will route its calls through these and emit uniform translated toasts ("Opdateret." / "Fejl [fejlkode]") instead of the raw untranslated backend keys that currently reach the screen (e.g. `CalendarTaskCreatedSuccessfully`). That plugin PR follows once this is merged (plugin CI compiles against this repo's `stable`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)