### PR TITLE
fix: match backend-config task-list batch dropdown typography to mockup

### DIFF
--- a/eform-client/src/scss/components/_material-dropdown.scss
+++ b/eform-client/src/scss/components/_material-dropdown.scss
@@ -580,14 +580,15 @@ body {
 // conventions (opgaveliste.html #opgavelisteFilterHandling): bold optgroup
 // headers (font-weight 700), regular-weight options, and clearly gray disabled
 // options (native GrayText ≈ #808080, vs the subtle theme disabled token).
-body .ng-dropdown-panel .ng-optgroup .tl-batch-action-group-label {
+.ng-dropdown-panel .tl-batch-action-group-label {
   font-weight: 700;
 }
 
-body .ng-dropdown-panel .ng-option .tl-batch-action-option-label {
+.ng-dropdown-panel .tl-batch-action-option-label {
   font-weight: 400;
 }
 
-body .ng-dropdown-panel .ng-option.ng-option-disabled .tl-batch-action-option-label {
+.ng-dropdown-panel .ng-option-disabled .tl-batch-action-option-label {
   color: #808080;
+  color: GrayText;
 }

--- a/eform-client/src/scss/components/_material-dropdown.scss
+++ b/eform-client/src/scss/components/_material-dropdown.scss
@@ -579,7 +579,7 @@ body {
 // affect any other dropdown. Typography matches the mockup's native <select>
 // conventions (opgaveliste.html #opgavelisteFilterHandling): bold optgroup
 // headers (font-weight 700), regular-weight options, and clearly gray disabled
-// options (native GrayText ≈ #808080, vs the subtle theme disabled token).
+// options (the native GrayText system color, vs the subtle theme disabled token).
 .ng-dropdown-panel .tl-batch-action-group-label {
   font-weight: 700;
 }
@@ -589,6 +589,5 @@ body {
 }
 
 .ng-dropdown-panel .ng-option-disabled .tl-batch-action-option-label {
-  color: #808080;
   color: GrayText;
 }

--- a/eform-client/src/scss/components/_material-dropdown.scss
+++ b/eform-client/src/scss/components/_material-dropdown.scss
@@ -571,3 +571,23 @@ body {
     z-index: 100000;
   }
 }
+
+// Task-list batch-action dropdown (backend-configuration task-list page).
+// The mtx-select panel is appended to <body> (mtx-select appendTo defaults to
+// 'body'), so these rules must be global; they are scoped by classes emitted
+// ONLY by that dropdown's ng-optgroup-tmp / ng-option-tmp templates and cannot
+// affect any other dropdown. Typography matches the mockup's native <select>
+// conventions (opgaveliste.html #opgavelisteFilterHandling): bold optgroup
+// headers (font-weight 700), regular-weight options, and clearly gray disabled
+// options (native GrayText ≈ #808080, vs the subtle theme disabled token).
+body .ng-dropdown-panel .ng-optgroup .tl-batch-action-group-label {
+  font-weight: 700;
+}
+
+body .ng-dropdown-panel .ng-option .tl-batch-action-option-label {
+  font-weight: 400;
+}
+
+body .ng-dropdown-panel .ng-option.ng-option-disabled .tl-batch-action-option-label {
+  color: #808080;
+}

--- a/eform-client/src/scss/components/_material-dropdown.scss
+++ b/eform-client/src/scss/components/_material-dropdown.scss
@@ -586,6 +586,9 @@ body {
 
 .ng-dropdown-panel .tl-batch-action-option-label {
   font-weight: 400;
+  // Options indent relative to their flush-left group headers, matching the
+  // mockup's native <select> optgroup rendering.
+  padding-left: 12px;
 }
 
 .ng-dropdown-panel .ng-option-disabled .tl-batch-action-option-label {


### PR DESCRIPTION
Tightly-scoped global SCSS for the backend-configuration task-list batch-action dropdown's body-appended mtx-select panel:

- bold (700) optgroup headers
- regular-weight (400) options
- clearly gray (#808080, native GrayText) disabled options

Rules are keyed on classes (`tl-batch-action-group-label` / `tl-batch-action-option-label`) emitted ONLY by that dropdown's `ng-optgroup-tmp` / `ng-option-tmp` templates (shipped in eform-backendconfiguration-plugin PR #1069, commit fac2d2a6), so no other dropdown is affected. Companion change — the plugin renders fine (theme typography) until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)